### PR TITLE
Introduce a `production` profile to use a JNDI datasource instead of the datasource instantiated by the .war application.

### DIFF
--- a/src/main/resources/spring/business-config.xml
+++ b/src/main/resources/spring/business-config.xml
@@ -20,7 +20,7 @@
 
     <!-- Configurer that replaces ${...} placeholders with values from a properties file -->
     <!-- (in this case, JDBC-related settings for the JPA EntityManager definition below) -->
-    <context:property-placeholder location="classpath:spring/data-access.properties"/>
+    <context:property-placeholder location="classpath:spring/data-access.properties" system-properties-mode="OVERRIDE"/>
 
      <!-- enables scanning for @Transactional annotations -->
     <tx:annotation-driven />
@@ -52,7 +52,7 @@
 
     </beans>
 
-    <beans profile="jdbc">
+    <beans profile="default,jdbc">
         <!-- Transaction manager for a single JDBC DataSource (alternative to JTA) -->
         <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager"
               p:dataSource-ref="dataSource"/>

--- a/src/main/resources/spring/datasource-config.xml
+++ b/src/main/resources/spring/datasource-config.xml
@@ -5,11 +5,14 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:jee="http://www.springframework.org/schema/jee"
        xmlns:jdbc="http://www.springframework.org/schema/jdbc"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
          http://www.springframework.org/schema/beans/spring-beans.xsd
          http://www.springframework.org/schema/context
          http://www.springframework.org/schema/context/spring-context.xsd
+         http://www.springframework.org/schema/jee
+         http://www.springframework.org/schema/jee/spring-jee.xsd
          http://www.springframework.org/schema/jdbc
          http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
@@ -17,19 +20,15 @@
 
     <!-- Configurer that replaces ${...} placeholders with values from a properties file -->
     <!-- (in this case, JDBC-related settings for the dataSource definition below) -->
-    <context:property-placeholder location="classpath:spring/data-access.properties"/>
+    <context:property-placeholder location="classpath:spring/data-access.properties" system-properties-mode="OVERRIDE"/>
 
-    <!-- DataSource configuration for the tomcat jdbc connection pool 
-    See here for more details on commons-dbcp versus tomcat-jdbc: 
+
+    <!-- DataSource configuration for the tomcat jdbc connection pool
+    See here for more details on commons-dbcp versus tomcat-jdbc:
     http://blog.ippon.fr/2013/03/13/improving-the-performance-of-the-spring-petclinic-sample-application-part-3-of-5/-->
     <bean id="dataSource" class="org.apache.tomcat.jdbc.pool.DataSource"
           p:driverClassName="${jdbc.driverClassName}" p:url="${jdbc.url}"
           p:username="${jdbc.username}" p:password="${jdbc.password}"/>
-
-    <!-- JNDI DataSource for JEE environments -->
-    <!--
-    <jee:jndi-lookup id="dataSource" jndi-name="java:comp/env/jdbc/petclinic"/>
-    -->
 
     <!-- Database initializer. If any of the script fails, the initialization stops. -->
     <!-- As an alternative, for embedded databases see <jdbc:embedded-database/>. -->
@@ -38,4 +37,8 @@
         <jdbc:script location="${jdbc.dataLocation}"/>
     </jdbc:initialize-database>
 
+    <beans profile="production" >
+        <!-- JNDI DataSource for JEE environments -->
+        <jee:jndi-lookup id="dataSource" jndi-name="java:comp/env/jdbc/petclinic"/>
+    </beans>
 </beans>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -8,15 +8,21 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     <display-name>Spring PetClinic</display-name>
     <description>Spring PetClinic sample application</description>
 
+    <!--
+    You can override the default profile ('jdbc') with
+     - jpa: in the case of plain JPA
+     - spring-data-jpa: in the case of Spring Data JPA
+
+    You can also combine the repositories implementation profile ('jdbc', 'jpa' or 'spring-data-jpa')
+    with the 'production' profile to us a JNDI datasource that would be provided by the container.
+    Sample to combine JPA repository and jndi datasource: 'jpa,production'
+
+    Sample:
     <context-param>
         <param-name>spring.profiles.active</param-name>
-        <param-value>jdbc</param-value>
-        <!-- Available profiles:
-		<param-value>jdbc</param-value>
-		<param-value>jpa</param-value> (in the case of plain JPA)
-		<param-value>spring-data-jpa</param-value> (in the case of Spring Data JPA)
-		-->
+		<param-value>jpa</param-value>
     </context-param>
+    -->
 
     <!--
 		- Location of the XML file that defines the root application context.


### PR DESCRIPTION
Hello, I discussed the ideas of this pull request with @jhoeller at GeekOut; Juergen did not see the code.

The purpose of this change is to allow to deploy Spring PetClinic on a tomcat-mysql environment without any code change, just overriding few configuration parameters with system properties (see sample at http://petclinic.examples.cloudbees.net/ ).

Details:
1. Associate the JDBC repositories implementation with the `default` profile in addition to the existing association with the `jdbc` profile -> file business-config.xml,
2. Remove the `spring.profiles.active` web context-param to allow overriding of the application's profile by a system property; unless overridden by a system property `spring.profiles.active`, the web app uses the profile `default` -> file web.xml,
3. Allow to override values of `data-access.properties` with system properties (`<context:property-placeholder ... system-properties-mode="OVERRIDE"/>`) -> files business-config.xml and datasource-config.xml,
4. Introduce a `production` profile to use the JNDI datasource instead of the embedded datasource -> file datasource-config.xml
