### PR TITLE
Spring MVC should server static resources (*.html, ...) located in src/main/webapp instead of returning "404 Not Found"

### DIFF
--- a/src/main/resources/spring/mvc-core-config.xml
+++ b/src/main/resources/spring/mvc-core-config.xml
@@ -33,6 +33,9 @@
 
     <mvc:view-controller path="/" view-name="welcome" />
 
+    <!-- serve static resources (*.html, ...) from src/main/webapp/ -->
+    <mvc:default-servlet-handler/>
+
     <bean id="conversionService" class="org.springframework.format.support.FormattingConversionServiceFactoryBean">
         <property name="formatters">
             <set>


### PR DESCRIPTION
Spring MVC should server static resources (*.html, ...) located in src/main/webapp instead of returning "404 Not Found".

It's common to use spring-petclinic as a skeleton to develop Spring MVC apps. Developers are surprised to not see their static resources (*.html, ...) dropped under src/main/webapp but to instead have a "404 Not Found".

cc @harpreetsingh
