### PR TITLE
petclinic_db_setup_mysql.txt references wrong file, fixed instructions for implementing mysql db

### DIFF
--- a/src/main/resources/db/mysql/petclinic_db_setup_mysql.txt
+++ b/src/main/resources/db/mysql/petclinic_db_setup_mysql.txt
@@ -19,6 +19,9 @@
 3) Create the PetClinic database and user by executing the "db/mysql/initDB.sql"
    script.
 
-4) Open "src/main/resources/spring/jdbc.properties"; comment out all properties in the
+4) Populate the PetClinic database with sample data by executing the 
+   "db/mysql/populateDB.sql" script.
+
+5) Open "src/main/resources/spring/jdbc.properties"; comment out all properties in the
    "HSQL Settings" section; uncomment all properties in the "MySQL Settings"
    section.


### PR DESCRIPTION
The petclinic_db_setup_mysql.txt file should reference the initDB.sql script, not itself. 
