### PR TITLE
Fixes #37 with other default locale than english

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
@@ -1,5 +1,6 @@
 package org.springframework.samples.petclinic.model;
 
+import java.util.Locale;
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
@@ -10,6 +11,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
@@ -32,6 +34,7 @@ public class ValidatorTests {
 	@Test
     public void emptyFirstName() {
 
+	LocaleContextHolder.setLocale(Locale.ENGLISH);
         Person person = new Person();
         person.setFirstName("");
         person.setLastName("smith");


### PR DESCRIPTION
Test in error with french default Locale:
org.junit.ComparisonFailure: expected:<[ne peut pas être vide]> but was:<[may not be empty]>
    at org.junit.Assert.assertEquals(Assert.java:115)
    at org.junit.Assert.assertEquals(Assert.java:144)
    at org.springframework.samples.petclinic.model.ValidatorTests.emptyFirstName(ValidatorTests.java:39)
