### PR TITLE
Upgraded Dandelion-Datatables to the latest release (v0.10.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<webjars-bootstrap.version>2.3.0</webjars-bootstrap.version>
 		<webjars-jquery-ui.version>1.10.3</webjars-jquery-ui.version>
 		<webjars-jquery.version>2.0.3-1</webjars-jquery.version>
-		<dandelion.datatables.version>0.9.3</dandelion.datatables.version>
+		<dandelion.version>0.10.0</dandelion.version>
 
 		<mysql.version>5.1.22</mysql.version>
 
@@ -303,19 +303,13 @@
 		<dependency>
 			<groupId>com.github.dandelion</groupId>
 			<artifactId>datatables-jsp</artifactId>
-			<version>${dandelion.datatables.version}</version>
+			<version>${dandelion.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.dandelion</groupId>
 			<artifactId>datatables-export-itext</artifactId>
-			<version>${dandelion.datatables.version}</version>
+			<version>${dandelion.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>com.github.dandelion</groupId>
-			<artifactId>datatables-servlet2</artifactId>
-			<version>${dandelion.datatables.version}</version>
-		</dependency>
-
 
 	</dependencies>
 

--- a/src/main/resources/dandelion/datatables/datatables.properties
+++ b/src/main/resources/dandelion/datatables/datatables.properties
@@ -1,0 +1,6 @@
+# ==================================
+# Dandelion-Datatables configuration
+# ==================================
+
+# Disable the asset management of Dandelion-Core for all non-DataTable-related assets
+main.standalone=true

--- a/src/main/webapp/WEB-INF/jsp/owners/ownersList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/owners/ownersList.jsp
@@ -15,8 +15,8 @@
     <jsp:include page="../fragments/bodyHeader.jsp"/>
     <h2>Owners</h2>
     
-    <datatables:table id="owners" data="${selections}" cdn="true" row="owner" theme="bootstrap2" 
-                      cssClass="table table-striped" paginate="false" info="false" export="pdf">
+    <datatables:table id="owners" data="${selections}" row="owner" theme="bootstrap2" 
+                      cssClass="table table-striped" pageable="false" info="false" export="pdf">
         <datatables:column title="Name" cssStyle="width: 150px;" display="html">
             <spring:url value="/owners/{ownerId}.html" var="ownerUrl">
                 <spring:param name="ownerId" value="${owner.id}"/>
@@ -34,7 +34,7 @@
                 <c:out value="${pet.name}"/>
             </c:forEach>
         </datatables:column>
-        <datatables:export type="pdf" cssClass="btn btn-small" />
+        <datatables:export type="pdf" cssClass="btn" cssStyle="height: 25px;" />
     </datatables:table>
     
     <jsp:include page="../fragments/footer.jsp"/>

--- a/src/main/webapp/WEB-INF/jsp/vets/vetList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/vets/vetList.jsp
@@ -16,7 +16,7 @@
 
     <h2>Veterinarians</h2>
 
-    <datatables:table id="vets" data="${vets.vetList}" cdn="true" row="vet" theme="bootstrap2" cssClass="table table-striped" paginate="false" info="false">
+    <datatables:table id="vets" data="${vets.vetList}" row="vet" theme="bootstrap2" cssClass="table table-striped" pageable="false" info="false">
         <datatables:column title="Name">
             <c:out value="${vet.firstName} ${vet.lastName}"></c:out>
         </datatables:column>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -58,17 +58,26 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
         <url-pattern>/</url-pattern>
     </servlet-mapping>
 
-    <!-- Dandelion-Datatables servlet definition -->
+    <!-- Dandelion servlet definition and mapping -->
     <servlet>
-        <servlet-name>datatablesController</servlet-name>
-        <servlet-class>com.github.dandelion.datatables.extras.servlet2.servlet.DatatablesServlet</servlet-class>
+        <servlet-name>dandelionServlet</servlet-name>
+        <servlet-class>com.github.dandelion.core.web.DandelionServlet</servlet-class>
+        <load-on-startup>2</load-on-startup>
     </servlet>
-   
-    <!-- Dandelion-Datatables servlet mapping -->
     <servlet-mapping>
-        <servlet-name>datatablesController</servlet-name>
-        <url-pattern>/datatablesController/*</url-pattern>
+        <servlet-name>dandelionServlet</servlet-name>
+        <url-pattern>/dandelion-assets/*</url-pattern>
     </servlet-mapping>
+   
+    <!-- Dandelion filter definition and mapping -->
+    <filter>
+        <filter-name>dandelionFilter</filter-name>
+        <filter-class>com.github.dandelion.core.web.DandelionFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>dandelionFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
 
     <!-- used so we can use forms of method type 'PUT' and 'DELETE' (such as in the Pet form)
 see here: http://static.springsource.org/spring/docs/current/spring-framework-reference/html/view.html#rest-method-conversion
@@ -102,17 +111,15 @@ see here: http://static.springsource.org/spring/docs/current/spring-framework-re
 	    <url-pattern>/*</url-pattern>
 	 </filter-mapping>
  
-     <!-- Dandelion-Datatables filter definition -->
-    <filter>
-        <filter-name>datatablesFilter</filter-name>
-        <filter-class>com.github.dandelion.datatables.extras.servlet2.filter.DatatablesFilter</filter-class>
-    </filter>
-    
-    <!-- Dandelion-Datatables filter mapping -->
-    <filter-mapping>
-        <filter-name>datatablesFilter</filter-name>
+     <!-- Dandelion-Datatables filter, used for basic export -->
+     <filter>
+        <filter-name>datatables</filter-name>
+        <filter-class>com.github.dandelion.datatables.core.web.filter.DatatablesFilter</filter-class>
+     </filter>
+     <filter-mapping>
+        <filter-name>datatables</filter-name>
         <url-pattern>/*</url-pattern>
-    </filter-mapping>
+     </filter-mapping>
     
     <!--  	No need for welcome-file declaration here.
     		See inside spring/mvc-core-config.xml : 


### PR DESCRIPTION
- The old datatables-servlet2 dependency has been removed from the `pom.xml`. It doesn't exist any longer.
- Some attributes have been renamed (e.g. paginate => pageable)
- Starting from the v0.10.0, all web components (servlet, filter) must be explicitely declared in the `web.xml` file. That's why I added the following declaration: DandelionFilter, DandelionServlet and DatatablesFilter
- Added a new `src/main/resources/dandelion/datatables/datatables.properties` file in order to disable the asset management brought by Dandelion-Core. This is equivalent to the old `cdn=true` table attribute
