### PR TITLE
fix for JasperException when java8 is used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,7 @@
 			<plugin>
 				<groupId>org.apache.tomcat.maven</groupId>
 				<artifactId>tomcat7-maven-plugin</artifactId>
-				<version>2.0</version>
+				<version>2.2</version>
 				<configuration>
 					<server>tomcat-development-server</server>
 					<port>9966</port>


### PR DESCRIPTION
When java8 is used as default JDK the application throws exception when you try to access it.
Consider the following sequence:

1. java -version

        java version "1.8.0_20"
        Java(TM) SE Runtime Environment (build 1.8.0_20-b26)
        Java HotSpot(TM) 64-Bit Server VM (build 25.20-b23, mixed mode)

2. git clone https://github.com/komarevsky/spring-petclinic.git
3. cd spring-petclinic
4. mvn clean install
5. mvn tomcat7:run
6. open in browser "http://localhost:9966/petclinic/"

You will see the following:

HTTP Status 500 - Unable to compile class for JSP:

type Exception report

message Unable to compile class for JSP:

description The server encountered an internal error that prevented it from fulfilling this request.

exception

org.apache.jasper.JasperException: Unable to compile class for JSP:

An error occurred at line: 1 in the generated java file
The type java.util.Map$Entry cannot be resolved. It is indirectly referenced from required .class files

Stacktrace:
	org.apache.jasper.compiler.DefaultErrorHandler.javacError(DefaultErrorHandler.java:102)
	org.apache.jasper.compiler.ErrorDispatcher.javacError(ErrorDispatcher.java:331)
	org.apache.jasper.compiler.JDTCompiler.generateClass(JDTCompiler.java:469)
	org.apache.jasper.compiler.Compiler.compile(Compiler.java:378)
	....

Changing tomcat7-maven-plugin version from 2.0 to 2.2 helps to fix it.

Details are [here](http://stackoverflow.com/questions/19243458/tomcat7-not-compiling-jsp-examples)