### PR TITLE
Dandelion without cdn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,9 @@
 
 		<!-- Web dependencies -->
 		<webjars-bootstrap.version>2.3.0</webjars-bootstrap.version>
-		<webjars-jquery-ui.version>1.10.3</webjars-jquery-ui.version>
-		<webjars-jquery.version>2.0.3-1</webjars-jquery.version>
+		<webjars-jquery-ui.version>1.11.1</webjars-jquery-ui.version>
+		<webjars-jquery.version>2.1.1</webjars-jquery.version>
+        <webjars-datatables.version>1.9.4-2</webjars-datatables.version>
 		<dandelion.version>0.10.1</dandelion.version>
 
 		<mysql.version>5.1.22</mysql.version>
@@ -264,7 +265,12 @@
 			<artifactId>jquery</artifactId>
 			<version>${webjars-jquery.version}</version>
 		</dependency>
-		
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>datatables</artifactId>
+            <version>${webjars-datatables.version}</version>
+        </dependency>
+
 		<!-- Test Artifacts -->
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -310,6 +316,17 @@
 			<artifactId>datatables-export-itext</artifactId>
 			<version>${dandelion.version}</version>
 		</dependency>
+
+        <!--
+        webjars in Dandelion bundles
+        http://dandelion.github.io/dandelion/features/asset-bundles/introducing-asset-bundles.html
+        -->
+        <dependency>
+            <groupId>com.github.dandelion</groupId>
+            <artifactId>dandelion-webjars</artifactId>
+            <version>${dandelion.version}</version>
+        </dependency>
+
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/resources/dandelion/dandelion.properties
+++ b/src/main/resources/dandelion/dandelion.properties
@@ -1,0 +1,11 @@
+############################################
+# Dandelion configuration
+############################################
+
+# The 'petclinic' bundle will be included in all requests
+#  http://dandelion-forum.48353.x6.nabble.com/Error-in-bundle-dependencies-resolving-td1677.html
+#  http://dandelion-forum.48353.x6.nabble.com/Overriding-asset-bundles-doesn-t-work-td1678.html
+
+bundle.includes=petclinic
+
+#dandelion.mode=production

--- a/src/main/resources/dandelion/dandelion.properties
+++ b/src/main/resources/dandelion/dandelion.properties
@@ -3,9 +3,10 @@
 ############################################
 
 # The 'petclinic' bundle will be included in all requests
-#  http://dandelion-forum.48353.x6.nabble.com/Error-in-bundle-dependencies-resolving-td1677.html
-#  http://dandelion-forum.48353.x6.nabble.com/Overriding-asset-bundles-doesn-t-work-td1678.html
 
 bundle.includes=petclinic
 
+# Use for production:
+# http://dandelion.github.io/dandelion/features/development-mode/
+# http://dandelion.github.io/dandelion/features/production-mode/
 #dandelion.mode=production

--- a/src/main/resources/dandelion/datatables/datatables.properties
+++ b/src/main/resources/dandelion/datatables/datatables.properties
@@ -1,6 +1,0 @@
-# ==================================
-# Dandelion-Datatables configuration
-# ==================================
-
-# Disable the asset management of Dandelion-Core for all non-DataTable-related assets
-main.standalone=true

--- a/src/main/resources/dandelion/datatables/themes/bootstrap2/ddl-dt-theme-bootstrap2.json
+++ b/src/main/resources/dandelion/datatables/themes/bootstrap2/ddl-dt-theme-bootstrap2.json
@@ -1,0 +1,4 @@
+{
+    "bundle" : "ddl-dt-theme-bootstrap2",
+    "dependencies": [ "bootstrap2", "datatables" ]
+}

--- a/src/main/resources/dandelion/petclinic.json
+++ b/src/main/resources/dandelion/petclinic.json
@@ -1,0 +1,12 @@
+{
+    "bundle" : "petclinic",
+    "dependencies" : [ "bootstrap2", "jqueryui" ],
+    "assets": [{
+        "name": "petclinic",
+        "version": "1.0.0",
+        "type": "css",
+        "locations": {
+            "webapp": "/resources/css/petclinic.css"
+        }
+    }]
+}

--- a/src/main/resources/dandelion/vendor/bootstrap2.json
+++ b/src/main/resources/dandelion/vendor/bootstrap2.json
@@ -1,0 +1,22 @@
+{
+    "bundle": "bootstrap2",
+    "dependencies": [],
+    "assets": [
+        {
+            "name": "bootstrap2",
+            "version": "2.3.0",
+            "type": "js",
+            "locations": {
+                "webjar": "bootstrap.min.js"
+            }
+        },
+        {
+            "name": "bootstrap2",
+            "version": "2.3.0",
+            "type": "css",
+            "locations": {
+                "webjar": "bootstrap.min.css"
+            }
+        }
+    ]
+}

--- a/src/main/resources/dandelion/vendor/datatables.json
+++ b/src/main/resources/dandelion/vendor/datatables.json
@@ -1,0 +1,22 @@
+{
+    "bundle" : "datatables",
+    "dependencies": [ "jquery" ],
+    "assets": [
+        {
+            "name": "datatables",
+            "version": "1.10.2",
+            "type": "js",
+            "locations": {
+                "webjar": "jquery.dataTables.min.js"
+            }
+        },
+        {
+            "name": "datatables",
+            "version": "1.10.2",
+            "type": "css",
+            "locations": {
+                "webjar": "jquery.dataTables.css"
+            }
+        }
+    ]
+}

--- a/src/main/resources/dandelion/vendor/jquery.json
+++ b/src/main/resources/dandelion/vendor/jquery.json
@@ -1,0 +1,13 @@
+{
+    "bundle": "jquery",
+    "assets": [
+        {
+            "name": "jquery",
+            "version": "2.1.1",
+            "type": "js",
+            "locations": {
+                "webjar": "jquery.min.js"
+            }
+        }
+    ]
+}

--- a/src/main/resources/dandelion/vendor/jqueryui.json
+++ b/src/main/resources/dandelion/vendor/jqueryui.json
@@ -1,0 +1,22 @@
+{
+    "bundle": "jqueryui",
+    "dependencies": [ "jquery" ],
+    "assets": [
+        {
+            "name": "jqueryui",
+            "version": "1.11.1",
+            "type": "js",
+            "locations": {
+                "webjar": "jquery-ui.min.js"
+            }
+        },
+        {
+            "name": "jqueryui",
+            "version": "1.11.1",
+            "type": "css",
+            "locations": {
+                "webjar": "jquery-ui.min.css"
+            }
+        }
+    ]
+}

--- a/src/main/webapp/WEB-INF/jsp/fragments/headTag.jsp
+++ b/src/main/webapp/WEB-INF/jsp/fragments/headTag.jsp
@@ -7,27 +7,6 @@ PetClinic :: a Spring Framework demonstration
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>PetClinic :: a Spring Framework demonstration</title>
-
-
-    <spring:url value="/webjars/bootstrap/2.3.0/css/bootstrap.min.css" var="bootstrapCss"/>
-    <link href="${bootstrapCss}" rel="stylesheet"/>
-
-    <spring:url value="/resources/css/petclinic.css" var="petclinicCss"/>
-    <link href="${petclinicCss}" rel="stylesheet"/>
-
-    <spring:url value="/webjars/jquery/2.0.3/jquery.js" var="jQuery"/>
-    <script src="${jQuery}"></script>
-
-	<!-- jquery-ui.js file is really big so we only load what we need instead of loading everything -->
-    <spring:url value="/webjars/jquery-ui/1.10.3/ui/jquery.ui.core.js" var="jQueryUiCore"/>
-    <script src="${jQueryUiCore}"></script>
-
-	<spring:url value="/webjars/jquery-ui/1.10.3/ui/jquery.ui.datepicker.js" var="jQueryUiDatePicker"/>
-    <script src="${jQueryUiDatePicker}"></script>
-    
-    <!-- jquery-ui.css file is not that big so we can afford to load it -->
-    <spring:url value="/webjars/jquery-ui/1.10.3/themes/base/jquery-ui.css" var="jQueryUiCss"/>
-    <link href="${jQueryUiCss}" rel="stylesheet"></link>
 </head>
 
 

--- a/src/main/webapp/WEB-INF/jsp/pets/createOrUpdatePetForm.jsp
+++ b/src/main/webapp/WEB-INF/jsp/pets/createOrUpdatePetForm.jsp
@@ -11,11 +11,6 @@
 <jsp:include page="../fragments/headTag.jsp"/>
 <body>
 
-<script>
-    $(function () {
-        $("#birthDate").datepicker({ dateFormat: 'yy/mm/dd'});
-    });
-</script>
 <div class="container">
     <jsp:include page="../fragments/bodyHeader.jsp"/>
     <c:choose>
@@ -60,5 +55,9 @@
     <jsp:include page="../fragments/footer.jsp"/>
 </div>
 </body>
-
+<script>
+    $(function () {
+        $("#birthDate").datepicker({ dateFormat: 'yy/mm/dd'});
+    });
+</script>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/pets/createOrUpdateVisitForm.jsp
+++ b/src/main/webapp/WEB-INF/jsp/pets/createOrUpdateVisitForm.jsp
@@ -12,11 +12,6 @@
 
 
 <body>
-<script>
-    $(function () {
-        $("#date").datepicker({ dateFormat: 'yy/mm/dd'});
-    });
-</script>
 <div class="container">
     <jsp:include page="../fragments/bodyHeader.jsp"/>
     <h2><c:if test="${visit['new']}">New </c:if>Visit</h2>
@@ -82,5 +77,9 @@
 </div>
 <jsp:include page="../fragments/footer.jsp"/>
 </body>
-
+<script>
+    $(function () {
+        $("#date").datepicker({ dateFormat: 'yy/mm/dd'});
+    });
+</script>
 </html>


### PR DESCRIPTION
Switch all javascript and css to dandelion bandles (http://dandelion.github.io/dandelion/features/asset-bundles/) to eliminate datatables CDN in generated JSP.
Update jquery and jquery-ui.