### PR TITLE
Add comments to describe when AOP invoked

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,6 @@
 			<artifactId>taglibs-standard-jstlel</artifactId>
 		</dependency>
 		<!--  JSon -->
-	 	<dependency>
-		   <groupId>com.googlecode.json-simple</groupId>
-		   <artifactId>json-simple</artifactId>
-         </dependency>
 		 <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
 	 	<dependency>
 		   <groupId>com.googlecode.json-simple</groupId>
 		   <artifactId>json-simple</artifactId>
-		   <version>1.1</version>
          </dependency>
 		 <dependency>
             <groupId>com.jayway.jsonpath</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
 			<artifactId>taglibs-standard-jstlel</artifactId>
 		</dependency>
 		<!--  JSon -->
+	 	<dependency>
+		   <groupId>com.googlecode.json-simple</groupId>
+		   <artifactId>json-simple</artifactId>
+		   <version>1.1</version>
+         </dependency>
 		 <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>

--- a/src/main/java/org/springframework/samples/petclinic/util/CallMonitoringAspect.java
+++ b/src/main/java/org/springframework/samples/petclinic/util/CallMonitoringAspect.java
@@ -26,6 +26,8 @@ import org.springframework.util.StopWatch;
 /**
  * Simple aspect that monitors call count and call invocation time. It uses JMX annotations and therefore can be
  * monitored using any JMX console such as the jConsole
+ * 
+ * This is only useful if you use JPA or JDBC.  Spring-data-jpa doesn't have any correctly annotated classes to join on 
  *
  * @author Rob Harrop
  * @author Juergen Hoeller

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -8,6 +8,7 @@
     <display-name>Spring PetClinic</display-name>
     <description>Spring PetClinic sample application</description>
     
+   <!-- When using Spring jpa, use the following: -->
     <context-param>
         <param-name>spring.profiles.active</param-name>
         <param-value>jpa</param-value>
@@ -19,6 +20,7 @@
         <param-value>jdbc</param-value>
     </context-param>  -->
 
+   <!--  the  CallMonitoringAspect counts invocations on classes with @Repository on them. Classes in spring-data-jpa don't have that annotation  -->
    <!--  When using Spring Data JPA, uncomment the following: -->
    <!--
    	<context-param>


### PR DESCRIPTION
The AOP joinpoint won't be invoked to do call counting if running spring-data-jpa instead of jpa or jdbc.  Added comments in two places to that effect