### PR TITLE
Using jodatime LocalDate instead of DateTime for visits

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Visit.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Visit.java
@@ -23,7 +23,7 @@ import javax.persistence.Table;
 
 import org.hibernate.annotations.Type;
 import org.hibernate.validator.constraints.NotEmpty;
-import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
 
 /**
@@ -39,9 +39,9 @@ public class Visit extends BaseEntity {
      * Holds value of property date.
      */
     @Column(name = "visit_date")
-    @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
+    @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentLocalDate")
     @DateTimeFormat(pattern = "yyyy/MM/dd")
-    private DateTime date;
+    private LocalDate date;
 
     /**
      * Holds value of property description.
@@ -62,7 +62,7 @@ public class Visit extends BaseEntity {
      * Creates a new instance of Visit for the current date
      */
     public Visit() {
-        this.date = new DateTime();
+        this.date = new LocalDate();
     }
 
 
@@ -71,7 +71,7 @@ public class Visit extends BaseEntity {
      *
      * @return Value of property date.
      */
-    public DateTime getDate() {
+    public LocalDate getDate() {
         return this.date;
     }
 
@@ -80,7 +80,7 @@ public class Visit extends BaseEntity {
      *
      * @param date New value of property date.
      */
-    public void setDate(DateTime date) {
+    public void setDate(LocalDate date) {
         this.date = date;
     }
 

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRowMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRowMapper.java
@@ -16,7 +16,7 @@
 package org.springframework.samples.petclinic.repository.jdbc;
 
 
-import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.samples.petclinic.model.Visit;
 
@@ -35,7 +35,7 @@ class JdbcVisitRowMapper implements RowMapper<Visit> {
         Visit visit = new Visit();
         visit.setId(rs.getInt("visit_id"));
         Date visitDate = rs.getDate("visit_date");
-        visit.setDate(new DateTime(visitDate));
+        visit.setDate(new LocalDate(visitDate));
         visit.setDescription(rs.getString("description"));
         return visit;
     }


### PR DESCRIPTION
This is very similar to https://github.com/spring-projects/spring-petclinic/commit/92de6557e10b610f3ea6579a6be67c53c4f766bc

The bug https://github.com/spring-projects/spring-petclinic/issues/111 also holds for visit dates - not only for pet birthdays - this should fix it.