### PR TITLE
owners search has been case insensitive

### DIFF
--- a/src/main/resources/db/hsqldb/initDB.sql
+++ b/src/main/resources/db/hsqldb/initDB.sql
@@ -36,7 +36,7 @@ CREATE INDEX types_name ON types (name);
 CREATE TABLE owners (
   id         INTEGER IDENTITY PRIMARY KEY,
   first_name VARCHAR(30),
-  last_name  VARCHAR(30),
+  last_name  VARCHAR_IGNORECASE(30),
   address    VARCHAR(255),
   city       VARCHAR(80),
   telephone  VARCHAR(20)


### PR DESCRIPTION
It is not an SQL standard. It works well with HSQLDB. However, mysql VARCHAR already allows case insensitive search. I mean, developers who use mysql for petclinic db, they already do the case insensitive searches. It is for just HSQLDB. So, we do not need to make any change on mysql/initDB.sql. I tested case insensitive search with both HSQLDB and MYSQL. Everything looks fine. 
