### PR TITLE
Fix logback + JMX memory leak on web application reload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <!-- Date and Time -->

--- a/src/main/java/org/springframework/samples/petclinic/util/CleanUp.java
+++ b/src/main/java/org/springframework/samples/petclinic/util/CleanUp.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.util;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.LoggerContext;
+
+/**
+ * When the web application stops, various resources need to be cleaned up to
+ * prevent memory leaks.
+ */
+public class CleanUp implements ServletContextListener {
+
+    @Override
+    public void contextInitialized(ServletContextEvent arg0) {
+        // NO-OP
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent arg0) {
+        // Logback is configured to use JMX so make sure that all objects are
+        // deregistered from JMX else there will be a memory leak
+        // http://logback.qos.ch/manual/jmxConfig.html
+        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+        lc.stop();
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -8,7 +8,10 @@
     </contextListener>
 
     <!-- To enable JMX Management -->
+
     <jmxConfigurator/>
+    <!-- Avoid conflicts with other web applications using logback and JMX -->
+    <contextName>PetClinic</contextName>
 
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -42,6 +42,9 @@
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
     </listener>
 
+    <listener>
+        <listener-class>org.springframework.samples.petclinic.util.CleanUp</listener-class>
+    </listener>
     <!--
 - Servlet that dispatches request to registered handlers (Controller implementations).
 -->


### PR DESCRIPTION
I've been using Spring PetClinic to test memory leaks in Apache Tomcat and I've found a memory leak in PetClinic related to logback and JMX. This pull request fixes the leak but, given I have next to no Spring development experience, I may well have gone about fixing this completely the wrong way.