### PR TITLE
Improvements in VisitRepository.findByPetId implementation.

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
@@ -19,13 +19,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.VisitRepository;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A simple JDBC-based implementation of the {@link VisitRepository} interface.
@@ -41,13 +45,13 @@ import java.util.List;
 @Repository
 public class JdbcVisitRepositoryImpl implements VisitRepository {
 
-    private JdbcTemplate jdbcTemplate;
+    private NamedParameterJdbcTemplate jdbcTemplate;
 
     private SimpleJdbcInsert insertVisit;
 
     @Autowired
     public JdbcVisitRepositoryImpl(DataSource dataSource) {
-        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
 
         this.insertVisit = new SimpleJdbcInsert(dataSource)
             .withTableName("visits")
@@ -80,9 +84,22 @@ public class JdbcVisitRepositoryImpl implements VisitRepository {
 
     @Override
     public List<Visit> findByPetId(Integer petId) {
-        return this.jdbcTemplate.query(
-            "SELECT id as visit_id, visit_date, description FROM visits WHERE pet_id=?",
-            new JdbcVisitRowMapper(), petId);
+        Map<String, Object> params = new HashMap<>();
+        params.put("id", petId);
+        JdbcPet pet = this.jdbcTemplate.queryForObject(
+                "SELECT id, name, birth_date, type_id, owner_id FROM pets WHERE id=:id",
+                params,
+                new JdbcPetRowMapper());
+
+        List<Visit> visits = this.jdbcTemplate.query(
+            "SELECT id as visit_id, visit_date, description FROM visits WHERE pet_id=:id", 
+            params, new JdbcVisitRowMapper());
+        
+        for (Visit visit: visits) {
+            visit.setPet(pet);
+        }
+        
+        return visits;
     }
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryImpl.java
@@ -56,7 +56,7 @@ public class JpaVisitRepositoryImpl implements VisitRepository {
     @Override
     @SuppressWarnings("unchecked")
     public List<Visit> findByPetId(Integer petId) {
-        Query query = this.em.createQuery("SELECT visit FROM Visit v where v.pets.id= :id");
+        Query query = this.em.createQuery("SELECT v FROM Visit v where v.pet.id= :id");
         query.setParameter("id", petId);
         return query.getResultList();
     }

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
@@ -48,4 +48,6 @@ public interface ClinicService {
 
     Collection<Owner> findOwnerByLastName(String lastName) throws DataAccessException;
 
+	Collection<Visit> findVisitsByPetId(int petId);
+
 }

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -105,5 +105,10 @@ public class ClinicServiceImpl implements ClinicService {
         return vetRepository.findAll();
     }
 
+	@Override
+	public Collection<Visit> findVisitsByPetId(int petId) {
+		return visitRepository.findByPetId(petId);
+	}
+
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/service/AbstractClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/AbstractClinicServiceTests.java
@@ -190,5 +190,15 @@ public abstract class AbstractClinicServiceTests {
         assertThat(visit.getId()).isNotNull();
     }
 
+    @Test
+       public void shouldFindVisitsByPetId() throws Exception {
+        Collection<Visit> visits = this.clinicService.findVisitsByPetId(7);
+        assertThat(visits.size()).isEqualTo(2);
+        Visit[] visitArr = visits.toArray(new Visit[visits.size()]);
+        assertThat(visitArr[0].getPet()).isNotNull();
+        assertThat(visitArr[0].getDate()).isNotNull();
+        assertThat(visitArr[0].getPet().getId()).isEqualTo(7);
+    }
+
 
 }


### PR DESCRIPTION
Fixes #158.

- In the Jdbc implementation: pets belonging to a visit were not added.
- In the Jpa implementation: query variable was wrong.
- Test case: AbstractClinicServiceTests.shouldFindVisitsByPetId()