### PR TITLE
Extend base functionality and add Rest controllers

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
@@ -18,6 +18,8 @@ package org.springframework.samples.petclinic.model;
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 
+import org.hibernate.validator.constraints.NotEmpty;
+
 
 /**
  * Simple JavaBean domain object adds a name property to <code>BaseEntity</code>. Used as a base class for objects
@@ -30,6 +32,7 @@ import javax.persistence.MappedSuperclass;
 public class NamedEntity extends BaseEntity {
 
     @Column(name = "name")
+    @NotEmpty
     private String name;
 
     public String getName() {

--- a/src/main/java/org/springframework/samples/petclinic/model/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Owner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.Set;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.validation.constraints.Digits;
@@ -32,6 +33,9 @@ import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.beans.support.MutableSortDefinition;
 import org.springframework.beans.support.PropertyComparator;
 import org.springframework.core.style.ToStringCreator;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
 /**
  * Simple JavaBean domain object representing an owner.
@@ -43,6 +47,7 @@ import org.springframework.core.style.ToStringCreator;
  */
 @Entity
 @Table(name = "owners")
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class Owner extends Person {
     @Column(name = "address")
     @NotEmpty
@@ -57,7 +62,7 @@ public class Owner extends Person {
     @Digits(fraction = 0, integer = 10)
     private String telephone;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "owner")
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "owner", fetch = FetchType.EAGER)
     private Set<Pet> pets;
 
 

--- a/src/main/java/org/springframework/samples/petclinic/model/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Owner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,9 +34,6 @@ import org.springframework.beans.support.MutableSortDefinition;
 import org.springframework.beans.support.PropertyComparator;
 import org.springframework.core.style.ToStringCreator;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
 /**
  * Simple JavaBean domain object representing an owner.
  *
@@ -47,7 +44,6 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
  */
 @Entity
 @Table(name = "owners")
-@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class Owner extends Person {
     @Column(name = "address")
     @NotEmpty

--- a/src/main/java/org/springframework/samples/petclinic/model/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Pet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package org.springframework.samples.petclinic.model;
 
-import org.springframework.beans.support.MutableSortDefinition;
-import org.springframework.beans.support.PropertyComparator;
-import org.springframework.format.annotation.DateTimeFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -27,15 +30,15 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+
+import org.springframework.beans.support.MutableSortDefinition;
+import org.springframework.beans.support.PropertyComparator;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
 /**
  * Simple business object representing a pet.
@@ -46,6 +49,7 @@ import java.util.Set;
  */
 @Entity
 @Table(name = "pets")
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class Pet extends NamedEntity {
 
     @Column(name = "birth_date")

--- a/src/main/java/org/springframework/samples/petclinic/model/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Pet.java
@@ -89,7 +89,7 @@ public class Pet extends NamedEntity {
         return this.owner;
     }
 
-    protected void setOwner(Owner owner) {
+    public void setOwner(Owner owner) {
         this.owner = owner;
     }
 

--- a/src/main/java/org/springframework/samples/petclinic/model/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Pet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package org.springframework.samples.petclinic.model;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import org.springframework.beans.support.MutableSortDefinition;
+import org.springframework.beans.support.PropertyComparator;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -30,15 +30,15 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-
-import org.springframework.beans.support.MutableSortDefinition;
-import org.springframework.beans.support.PropertyComparator;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Simple business object representing a pet.

--- a/src/main/java/org/springframework/samples/petclinic/repository/OwnerRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/OwnerRepositoryExt.java
@@ -1,0 +1,15 @@
+package org.springframework.samples.petclinic.repository;
+
+import java.util.Collection;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Owner;
+
+public interface OwnerRepositoryExt extends OwnerRepository {
+	
+	Collection<Owner> findAll() throws DataAccessException;
+
+	void delete(Owner owner) throws DataAccessException;
+
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/OwnerRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/OwnerRepositoryExt.java
@@ -1,9 +1,30 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository;
 
 import java.util.Collection;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Owner;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 public interface OwnerRepositoryExt extends OwnerRepository {
 	

--- a/src/main/java/org/springframework/samples/petclinic/repository/PetRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/PetRepositoryExt.java
@@ -1,9 +1,30 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository;
 
 import java.util.Collection;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Pet;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 public interface PetRepositoryExt extends PetRepository {
 	

--- a/src/main/java/org/springframework/samples/petclinic/repository/PetRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/PetRepositoryExt.java
@@ -1,0 +1,14 @@
+package org.springframework.samples.petclinic.repository;
+
+import java.util.Collection;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Pet;
+
+public interface PetRepositoryExt extends PetRepository {
+	
+	Collection<Pet> findAll() throws DataAccessException;
+
+	void delete(Pet pet) throws DataAccessException;
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/PetTypeRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/PetTypeRepositoryExt.java
@@ -1,0 +1,18 @@
+package org.springframework.samples.petclinic.repository;
+
+import java.util.Collection;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.PetType;
+
+public interface PetTypeRepositoryExt {
+	
+	PetType findById(int id);
+	
+	Collection<PetType> findAll() throws DataAccessException;
+
+	void save(PetType petType) throws DataAccessException;
+	
+	void delete(PetType petType) throws DataAccessException;
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/PetTypeRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/PetTypeRepositoryExt.java
@@ -7,7 +7,7 @@ import org.springframework.samples.petclinic.model.PetType;
 
 public interface PetTypeRepositoryExt {
 	
-	PetType findById(int id);
+	PetType findById(int id) throws DataAccessException;
 	
 	Collection<PetType> findAll() throws DataAccessException;
 

--- a/src/main/java/org/springframework/samples/petclinic/repository/PetTypeRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/PetTypeRepositoryExt.java
@@ -1,9 +1,30 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository;
 
 import java.util.Collection;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.PetType;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 public interface PetTypeRepositoryExt {
 	

--- a/src/main/java/org/springframework/samples/petclinic/repository/SpecialtyRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/SpecialtyRepositoryExt.java
@@ -1,9 +1,30 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository;
 
 import java.util.Collection;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Specialty;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 public interface SpecialtyRepositoryExt {
 	

--- a/src/main/java/org/springframework/samples/petclinic/repository/SpecialtyRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/SpecialtyRepositoryExt.java
@@ -1,0 +1,18 @@
+package org.springframework.samples.petclinic.repository;
+
+import java.util.Collection;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Specialty;
+
+public interface SpecialtyRepositoryExt {
+	
+	Specialty findById(int id);
+	
+	Collection<Specialty> findAll() throws DataAccessException;
+	
+	void save(Specialty specialty) throws DataAccessException;
+	
+	void delete(Specialty specialty) throws DataAccessException;
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/SpecialtyRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/SpecialtyRepositoryExt.java
@@ -7,7 +7,7 @@ import org.springframework.samples.petclinic.model.Specialty;
 
 public interface SpecialtyRepositoryExt {
 	
-	Specialty findById(int id);
+	Specialty findById(int id) throws DataAccessException;
 	
 	Collection<Specialty> findAll() throws DataAccessException;
 	

--- a/src/main/java/org/springframework/samples/petclinic/repository/VetRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/VetRepositoryExt.java
@@ -1,0 +1,18 @@
+package org.springframework.samples.petclinic.repository;
+
+import java.util.Collection;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Vet;
+
+public interface VetRepositoryExt extends VetRepository {
+	
+	Vet findById(int id) throws DataAccessException;
+
+	Collection<Vet> findAll() throws DataAccessException;
+	
+	void save(Vet vet) throws DataAccessException;
+	
+	void delete(Vet vet) throws DataAccessException;
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/VetRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/VetRepositoryExt.java
@@ -1,9 +1,30 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository;
 
 import java.util.Collection;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Vet;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 public interface VetRepositoryExt extends VetRepository {
 	

--- a/src/main/java/org/springframework/samples/petclinic/repository/VisitRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/VisitRepositoryExt.java
@@ -1,9 +1,30 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository;
 
 import java.util.Collection;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Visit;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 public interface VisitRepositoryExt extends VisitRepository {
 	

--- a/src/main/java/org/springframework/samples/petclinic/repository/VisitRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/VisitRepositoryExt.java
@@ -1,0 +1,16 @@
+package org.springframework.samples.petclinic.repository;
+
+import java.util.Collection;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Visit;
+
+public interface VisitRepositoryExt extends VisitRepository {
+	
+	Visit findById(int id) throws DataAccessException;
+	
+	Collection<Visit> findAll() throws DataAccessException;
+
+	void delete(Visit visit) throws DataAccessException;
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryExtImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.jdbc;
 
 import java.util.Collection;
@@ -6,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.sql.DataSource;
+import javax.transaction.Transactional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -13,8 +30,15 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.OwnerRepositoryExt;
 import org.springframework.stereotype.Repository;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Repository
 @Qualifier("OwnerRepositoryExt")
@@ -41,10 +65,25 @@ public class JdbcOwnerRepositoryExtImpl extends JdbcOwnerRepositoryImpl implemen
 	}
 
 	@Override
+	@Transactional
 	public void delete(Owner owner) throws DataAccessException {
-		Map<String, Object> params = new HashMap<>();
-        params.put("id", owner.getId());
-        this.namedParameterJdbcTemplate.update("DELETE FROM owners WHERE id=:id", params);
+		Map<String, Object> owner_params = new HashMap<>();
+		owner_params.put("id", owner.getId());
+        List<Pet> pets = owner.getPets();
+        // cascade delete pets
+        for (Pet pet : pets){
+        	Map<String, Object> pet_params = new HashMap<>();
+        	pet_params.put("id", pet.getId());
+        	// cascade delete visits
+        	List<Visit> visits = pet.getVisits();
+            for (Visit visit : visits){
+            	Map<String, Object> visit_params = new HashMap<>();
+            	visit_params.put("id", visit.getId());
+            	this.namedParameterJdbcTemplate.update("DELETE FROM visits WHERE id=:id", visit_params);
+            }
+            this.namedParameterJdbcTemplate.update("DELETE FROM pets WHERE id=:id", pet_params);
+        }
+        this.namedParameterJdbcTemplate.update("DELETE FROM owners WHERE id=:id", owner_params);
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryExtImpl.java
@@ -18,12 +18,12 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @Qualifier("OwnerRepositoryExt")
-public class JdbcOwnerRepositoryImplExt extends JdbcOwnerRepositoryImpl implements OwnerRepositoryExt {
+public class JdbcOwnerRepositoryExtImpl extends JdbcOwnerRepositoryImpl implements OwnerRepositoryExt {
 	
     private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
   	@Autowired
-	public JdbcOwnerRepositoryImplExt(DataSource dataSource) {
+	public JdbcOwnerRepositoryExtImpl(DataSource dataSource) {
 		super(dataSource);
 		// TODO  super() ?
 	    this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryExtImpl.java
@@ -25,7 +25,6 @@ public class JdbcOwnerRepositoryExtImpl extends JdbcOwnerRepositoryImpl implemen
   	@Autowired
 	public JdbcOwnerRepositoryExtImpl(DataSource dataSource) {
 		super(dataSource);
-		// TODO  super() ?
 	    this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
@@ -50,6 +51,7 @@ import org.springframework.stereotype.Repository;
  * @author Antoine Rey
  */
 @Repository
+@Qualifier("OwnerRepository")
 public class JdbcOwnerRepositoryImpl implements OwnerRepository {
 
     private NamedParameterJdbcTemplate namedParameterJdbcTemplate;

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImplExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImplExt.java
@@ -1,0 +1,51 @@
+package org.springframework.samples.petclinic.repository.jdbc;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.repository.OwnerRepositoryExt;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Qualifier("OwnerRepositoryExt")
+public class JdbcOwnerRepositoryImplExt extends JdbcOwnerRepositoryImpl implements OwnerRepositoryExt {
+	
+    private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+  	@Autowired
+	public JdbcOwnerRepositoryImplExt(DataSource dataSource) {
+		super(dataSource);
+		// TODO  super() ?
+	    this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+	}
+
+	@Override
+	public Collection<Owner> findAll() throws DataAccessException {
+		List<Owner> owners = this.namedParameterJdbcTemplate.query(
+	            "SELECT id, first_name, last_name, address, city, telephone FROM owners",
+	            new HashMap<String, Object>(),
+	            BeanPropertyRowMapper.newInstance(Owner.class));
+		for (Owner owner : owners) {
+            loadPetsAndVisits(owner);
+        }
+	    return owners;
+	}
+
+	@Override
+	public void delete(Owner owner) throws DataAccessException {
+		Map<String, Object> params = new HashMap<>();
+        params.put("id", owner.getId());
+        this.namedParameterJdbcTemplate.update("DELETE FROM owners WHERE id=:id", params);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryExtImpl.java
@@ -19,12 +19,12 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @Qualifier("PetRepositoryExt")
-public class JdbcPetRepositoryImplExt extends JdbcPetRepositoryImpl implements PetRepositoryExt {
+public class JdbcPetRepositoryExtImpl extends JdbcPetRepositoryImpl implements PetRepositoryExt {
 	
 	private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
 	@Autowired
-    public JdbcPetRepositoryImplExt(DataSource dataSource,
+    public JdbcPetRepositoryExtImpl(DataSource dataSource,
     		@Qualifier("OwnerRepositoryExt") OwnerRepositoryExt ownerRepository,
     		@Qualifier("VisitRepositoryExt") VisitRepositoryExt visitRepository) {
 		super(dataSource, ownerRepository, visitRepository);

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryExtImpl.java
@@ -1,5 +1,6 @@
 package org.springframework.samples.petclinic.repository.jdbc;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -11,10 +12,13 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.repository.OwnerRepositoryExt;
 import org.springframework.samples.petclinic.repository.PetRepositoryExt;
 import org.springframework.samples.petclinic.repository.VisitRepositoryExt;
+import org.springframework.samples.petclinic.util.EntityUtils;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -22,23 +26,36 @@ import org.springframework.stereotype.Repository;
 public class JdbcPetRepositoryExtImpl extends JdbcPetRepositoryImpl implements PetRepositoryExt {
 	
 	private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
-
+	
 	@Autowired
     public JdbcPetRepositoryExtImpl(DataSource dataSource,
     		@Qualifier("OwnerRepositoryExt") OwnerRepositoryExt ownerRepository,
     		@Qualifier("VisitRepositoryExt") VisitRepositoryExt visitRepository) {
 		super(dataSource, ownerRepository, visitRepository);
-		// TODO  super () ?
 		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
 	}
 
 	@Override
 	public Collection<Pet> findAll() throws DataAccessException {
 		Map<String, Object> params = new HashMap<>();
-        return this.namedParameterJdbcTemplate.query(
-            "SELECT id, name, birth_date, type_id, owner_id FROM pets",
-            params,
-            BeanPropertyRowMapper.newInstance(Pet.class));
+		Collection<Pet> pets = new ArrayList<Pet>();
+		Collection<JdbcPet> jdbcPets = new ArrayList<JdbcPet>();
+		jdbcPets = this.namedParameterJdbcTemplate.
+    			query("SELECT pets.id, name, birth_date, type_id, owner_id FROM pets",
+        		params,
+        		new JdbcPetRowMapper());
+		Collection<PetType> petTypes = this.namedParameterJdbcTemplate.query(
+	            "SELECT id, name FROM types ORDER BY name", new HashMap<String, Object>(),
+	            BeanPropertyRowMapper.newInstance(PetType.class));
+		Collection<Owner> owners = this.namedParameterJdbcTemplate.query(
+	            "SELECT id, first_name, last_name, address, city, telephone FROM owners ORDER BY last_name", new HashMap<String, Object>(),
+	            BeanPropertyRowMapper.newInstance(Owner.class));
+		for(JdbcPet jdbcPet : jdbcPets){
+			jdbcPet.setType(EntityUtils.getById(petTypes, PetType.class, jdbcPet.getTypeId()));
+			jdbcPet.setOwner(EntityUtils.getById(owners, Owner.class, jdbcPet.getOwnerId()));
+			pets.add(jdbcPet);
+		}
+		return pets;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryExtImpl.java
@@ -1,8 +1,25 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.jdbc;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.sql.DataSource;
@@ -15,11 +32,17 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.OwnerRepositoryExt;
 import org.springframework.samples.petclinic.repository.PetRepositoryExt;
 import org.springframework.samples.petclinic.repository.VisitRepositoryExt;
 import org.springframework.samples.petclinic.util.EntityUtils;
 import org.springframework.stereotype.Repository;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Repository
 @Qualifier("PetRepositoryExt")
@@ -60,9 +83,16 @@ public class JdbcPetRepositoryExtImpl extends JdbcPetRepositoryImpl implements P
 
 	@Override
 	public void delete(Pet pet) throws DataAccessException {
-		Map<String, Object> params = new HashMap<>();
-        params.put("id", pet.getId());
-        this.namedParameterJdbcTemplate.update("DELETE FROM pets WHERE id=:id", params);
+		Map<String, Object> pet_params = new HashMap<>();
+		pet_params.put("id", pet.getId());
+        List<Visit> visits = pet.getVisits();
+        // cascade delete visits
+        for (Visit visit : visits){
+        	Map<String, Object> visit_params = new HashMap<>();
+        	visit_params.put("id", visit.getId());
+        	this.namedParameterJdbcTemplate.update("DELETE FROM visits WHERE id=:id", visit_params);
+        }
+        this.namedParameterJdbcTemplate.update("DELETE FROM pets WHERE id=:id", pet_params);
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImpl.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
@@ -47,6 +48,7 @@ import org.springframework.stereotype.Repository;
  * @author Mark Fisher
  */
 @Repository
+@Qualifier("PetRepository")
 public class JdbcPetRepositoryImpl implements PetRepository {
 
     private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
@@ -59,7 +61,9 @@ public class JdbcPetRepositoryImpl implements PetRepository {
 
 
     @Autowired
-    public JdbcPetRepositoryImpl(DataSource dataSource, OwnerRepository ownerRepository, VisitRepository visitRepository) {
+    public JdbcPetRepositoryImpl(DataSource dataSource,
+    		@Qualifier("OwnerRepository") OwnerRepository ownerRepository,
+    		@Qualifier("VisitRepository") VisitRepository visitRepository) {
         this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
 
         this.insertPet = new SimpleJdbcInsert(dataSource)

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImplExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImplExt.java
@@ -1,0 +1,51 @@
+package org.springframework.samples.petclinic.repository.jdbc;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.repository.OwnerRepositoryExt;
+import org.springframework.samples.petclinic.repository.PetRepositoryExt;
+import org.springframework.samples.petclinic.repository.VisitRepositoryExt;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Qualifier("PetRepositoryExt")
+public class JdbcPetRepositoryImplExt extends JdbcPetRepositoryImpl implements PetRepositoryExt {
+	
+	private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+	@Autowired
+    public JdbcPetRepositoryImplExt(DataSource dataSource,
+    		@Qualifier("OwnerRepositoryExt") OwnerRepositoryExt ownerRepository,
+    		@Qualifier("VisitRepositoryExt") VisitRepositoryExt visitRepository) {
+		super(dataSource, ownerRepository, visitRepository);
+		// TODO  super () ?
+		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+	}
+
+	@Override
+	public Collection<Pet> findAll() throws DataAccessException {
+		Map<String, Object> params = new HashMap<>();
+        return this.namedParameterJdbcTemplate.query(
+            "SELECT id, name, birth_date, type_id, owner_id FROM pets",
+            params,
+            BeanPropertyRowMapper.newInstance(Pet.class));
+	}
+
+	@Override
+	public void delete(Pet pet) throws DataAccessException {
+		Map<String, Object> params = new HashMap<>();
+        params.put("id", pet.getId());
+        this.namedParameterJdbcTemplate.update("DELETE FROM pets WHERE id=:id", params);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryExtImpl.java
@@ -1,9 +1,20 @@
 package org.springframework.samples.petclinic.repository.jdbc;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.repository.PetTypeRepositoryExt;
 import org.springframework.stereotype.Repository;
@@ -11,28 +22,62 @@ import org.springframework.stereotype.Repository;
 @Repository
 @Qualifier("PetTypeRepositoryExt")
 public class JdbcPetTypeRepositoryExtImpl implements PetTypeRepositoryExt {
+	
+	private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+	
+	private SimpleJdbcInsert insertPetType;
+	
+	@Autowired
+	public JdbcPetTypeRepositoryExtImpl(DataSource dataSource) {
+		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+		this.insertPetType = new SimpleJdbcInsert(dataSource)
+	            .withTableName("types")
+	            .usingGeneratedKeyColumns("id");
+	}
 
 	@Override
 	public PetType findById(int id) {
-		// TODO Auto-generated method stub
-		return null;
+		PetType petType;
+        try {
+            Map<String, Object> params = new HashMap<>();
+            params.put("id", id);
+            petType = this.namedParameterJdbcTemplate.queryForObject(
+                "SELECT id, name FROM types WHERE id= :id",
+                params,
+                BeanPropertyRowMapper.newInstance(PetType.class));
+        } catch (EmptyResultDataAccessException ex) {
+            throw new ObjectRetrievalFailureException(PetType.class, id);
+        }
+        return petType;
 	}
 
 	@Override
 	public Collection<PetType> findAll() throws DataAccessException {
-		// TODO Auto-generated method stub
-		return null;
+		Map<String, Object> params = new HashMap<>();
+        return this.namedParameterJdbcTemplate.query(
+            "SELECT id, name FROM types",
+            params,
+            BeanPropertyRowMapper.newInstance(PetType.class));
 	}
 
 	@Override
 	public void save(PetType petType) throws DataAccessException {
-		// TODO Auto-generated method stub
+		BeanPropertySqlParameterSource parameterSource = new BeanPropertySqlParameterSource(petType);
+		if (petType.isNew()) {
+            Number newKey = this.insertPetType.executeAndReturnKey(parameterSource);
+            petType.setId(newKey.intValue());
+        } else {
+            this.namedParameterJdbcTemplate.update("UPDATE types SET name=:name WHERE id=:id",
+                parameterSource);
+        }
 
 	}
 
 	@Override
 	public void delete(PetType petType) throws DataAccessException {
-		// TODO Auto-generated method stub
+		Map<String, Object> params = new HashMap<>();
+        params.put("id", petType.getId());
+        this.namedParameterJdbcTemplate.update("DELETE FROM types WHERE id=:id", params);
 
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryExtImpl.java
@@ -1,0 +1,39 @@
+package org.springframework.samples.petclinic.repository.jdbc;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.repository.PetTypeRepositoryExt;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Qualifier("PetTypeRepositoryExt")
+public class JdbcPetTypeRepositoryExtImpl implements PetTypeRepositoryExt {
+
+	@Override
+	public PetType findById(int id) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Collection<PetType> findAll() throws DataAccessException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void save(PetType petType) throws DataAccessException {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void delete(PetType petType) throws DataAccessException {
+		// TODO Auto-generated method stub
+
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryExtImpl.java
@@ -70,7 +70,6 @@ public class JdbcPetTypeRepositoryExtImpl implements PetTypeRepositoryExt {
             this.namedParameterJdbcTemplate.update("UPDATE types SET name=:name WHERE id=:id",
                 parameterSource);
         }
-
 	}
 
 	@Override
@@ -78,7 +77,6 @@ public class JdbcPetTypeRepositoryExtImpl implements PetTypeRepositoryExt {
 		Map<String, Object> params = new HashMap<>();
         params.put("id", petType.getId());
         this.namedParameterJdbcTemplate.update("DELETE FROM types WHERE id=:id", params);
-
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcSpecialtyRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcSpecialtyRepositoryExtImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.jdbc;
 
 import java.util.Collection;
@@ -18,6 +34,11 @@ import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.samples.petclinic.model.Specialty;
 import org.springframework.samples.petclinic.repository.SpecialtyRepositoryExt;
 import org.springframework.stereotype.Repository;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Repository
 @Qualifier("SpecialtyRepositoryExt")
@@ -77,6 +98,7 @@ public class JdbcSpecialtyRepositoryExtImpl implements SpecialtyRepositoryExt {
 	public void delete(Specialty specialty) throws DataAccessException {
 		Map<String, Object> params = new HashMap<>();
         params.put("id", specialty.getId());
+        this.namedParameterJdbcTemplate.update("DELETE FROM vet_specialties WHERE specialty_id=:id", params);
         this.namedParameterJdbcTemplate.update("DELETE FROM specialties WHERE id=:id", params);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcSpecialtyRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcSpecialtyRepositoryExtImpl.java
@@ -1,9 +1,20 @@
 package org.springframework.samples.petclinic.repository.jdbc;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.samples.petclinic.model.Specialty;
 import org.springframework.samples.petclinic.repository.SpecialtyRepositoryExt;
 import org.springframework.stereotype.Repository;
@@ -11,29 +22,65 @@ import org.springframework.stereotype.Repository;
 @Repository
 @Qualifier("SpecialtyRepositoryExt")
 public class JdbcSpecialtyRepositoryExtImpl implements SpecialtyRepositoryExt {
+	
+	private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+	
+	private SimpleJdbcInsert insertSpecialty;
+
+	@Autowired
+	public JdbcSpecialtyRepositoryExtImpl(DataSource dataSource) {
+		// TODO Auto-generated constructor stub
+		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+		
+		this.insertSpecialty = new SimpleJdbcInsert(dataSource)
+	            .withTableName("specialties")
+	            .usingGeneratedKeyColumns("id");
+	}
 
 	@Override
 	public Specialty findById(int id) {
-		// TODO Auto-generated method stub
-		return null;
+		Specialty specialty;
+        try {
+            Map<String, Object> params = new HashMap<>();
+            params.put("id", id);
+            specialty = this.namedParameterJdbcTemplate.queryForObject(
+                "SELECT id, name FROM specialties WHERE id= :id",
+                params,
+                BeanPropertyRowMapper.newInstance(Specialty.class));
+        } catch (EmptyResultDataAccessException ex) {
+            throw new ObjectRetrievalFailureException(Specialty.class, id);
+        }
+        return specialty;
 	}
 
 	@Override
 	public Collection<Specialty> findAll() throws DataAccessException {
-		// TODO Auto-generated method stub
-		return null;
+		Map<String, Object> params = new HashMap<>();
+        return this.namedParameterJdbcTemplate.query(
+            "SELECT id, name FROM specialties",
+            params,
+            BeanPropertyRowMapper.newInstance(Specialty.class));
 	}
 
 	@Override
 	public void save(Specialty specialty) throws DataAccessException {
-		// TODO Auto-generated method stub
+		// TODO  not sure - need verify correct insert
+		BeanPropertySqlParameterSource parameterSource = new BeanPropertySqlParameterSource(specialty);
+		if (specialty.isNew()) {
+            Number newKey = this.insertSpecialty.executeAndReturnKey(parameterSource);
+            specialty.setId(newKey.intValue());
+        } else {
+            this.namedParameterJdbcTemplate.update("UPDATE specialties SET name=:name WHERE id=:id",
+                parameterSource);
+        }
 
 	}
 
 	@Override
 	public void delete(Specialty specialty) throws DataAccessException {
-		// TODO Auto-generated method stub
-
+		Map<String, Object> params = new HashMap<>();
+        params.put("id", specialty.getId());
+        this.namedParameterJdbcTemplate.update("DELETE FROM specialties WHERE id=:id", params);
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcSpecialtyRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcSpecialtyRepositoryExtImpl.java
@@ -64,7 +64,6 @@ public class JdbcSpecialtyRepositoryExtImpl implements SpecialtyRepositoryExt {
 
 	@Override
 	public void save(Specialty specialty) throws DataAccessException {
-		// TODO  not sure - need verify correct insert
 		BeanPropertySqlParameterSource parameterSource = new BeanPropertySqlParameterSource(specialty);
 		if (specialty.isNew()) {
             Number newKey = this.insertSpecialty.executeAndReturnKey(parameterSource);

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcSpecialtyRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcSpecialtyRepositoryExtImpl.java
@@ -29,9 +29,7 @@ public class JdbcSpecialtyRepositoryExtImpl implements SpecialtyRepositoryExt {
 
 	@Autowired
 	public JdbcSpecialtyRepositoryExtImpl(DataSource dataSource) {
-		// TODO Auto-generated constructor stub
 		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
-		
 		this.insertSpecialty = new SimpleJdbcInsert(dataSource)
 	            .withTableName("specialties")
 	            .usingGeneratedKeyColumns("id");

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcSpecialtyRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcSpecialtyRepositoryExtImpl.java
@@ -1,9 +1,6 @@
-package org.springframework.samples.petclinic.repository.jpa;
+package org.springframework.samples.petclinic.repository.jdbc;
 
 import java.util.Collection;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
@@ -13,34 +10,30 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @Qualifier("SpecialtyRepositoryExt")
-public class JpaSpecialtyRepositoryExtImpl implements SpecialtyRepositoryExt {
-	
-    @PersistenceContext
-    private EntityManager em;
+public class JdbcSpecialtyRepositoryExtImpl implements SpecialtyRepositoryExt {
 
 	@Override
 	public Specialty findById(int id) {
-		return this.em.find(Specialty.class, id);
+		// TODO Auto-generated method stub
+		return null;
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public Collection<Specialty> findAll() throws DataAccessException {
-		return this.em.createQuery("SELECT s FROM Specialty s").getResultList();
+		// TODO Auto-generated method stub
+		return null;
 	}
 
 	@Override
 	public void save(Specialty specialty) throws DataAccessException {
-		if (specialty.getId() == null) {
-            this.em.persist(specialty);
-        } else {
-            this.em.merge(specialty);
-        }
+		// TODO Auto-generated method stub
+
 	}
 
 	@Override
 	public void delete(Specialty specialty) throws DataAccessException {
-		this.em.remove(specialty);
+		// TODO Auto-generated method stub
+
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVetRepositoryExtImpl.java
@@ -1,6 +1,27 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.jdbc;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.sql.DataSource;
@@ -15,61 +36,85 @@ import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.orm.ObjectRetrievalFailureException;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.model.Specialty;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.repository.VetRepositoryExt;
+import org.springframework.samples.petclinic.util.EntityUtils;
 import org.springframework.stereotype.Repository;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Repository
 @Qualifier("VetRepositoryExt")
 public class JdbcVetRepositoryExtImpl extends JdbcVetRepositoryImpl implements VetRepositoryExt {
-	
-    private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
-    private SimpleJdbcInsert insertVet;
+	private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+	private SimpleJdbcInsert insertVet;
 
 	@Autowired
 	public JdbcVetRepositoryExtImpl(DataSource dataSource, JdbcTemplate jdbcTemplate) {
 		super(jdbcTemplate);
-        this.insertVet = new SimpleJdbcInsert(dataSource)
-                .withTableName("vets")
-                .usingGeneratedKeyColumns("id");
-        this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+		this.insertVet = new SimpleJdbcInsert(dataSource).withTableName("vets").usingGeneratedKeyColumns("id");
+		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
 	}
 
 	@Override
 	public Vet findById(int id) throws DataAccessException {
-        Vet vet;
-        try {
-            Map<String, Object> params = new HashMap<>();
-            params.put("id", id);
-            vet = this.namedParameterJdbcTemplate.queryForObject(
-                "SELECT id, first_name, last_name FROM vets WHERE id= :id",
-                params,
-                BeanPropertyRowMapper.newInstance(Vet.class));
-        } catch (EmptyResultDataAccessException ex) {
-            throw new ObjectRetrievalFailureException(Vet.class, id);
-        }
-        return vet;
+		Vet vet;
+		try {
+			Map<String, Object> vet_params = new HashMap<>();
+			vet_params.put("id", id);
+			vet = this.namedParameterJdbcTemplate.queryForObject(
+					"SELECT id, first_name, last_name FROM vets WHERE id= :id",
+					vet_params,
+					BeanPropertyRowMapper.newInstance(Vet.class));
+
+			final List<Specialty> specialties = this.namedParameterJdbcTemplate.query(
+					"SELECT id, name FROM specialties", vet_params, BeanPropertyRowMapper.newInstance(Specialty.class));
+
+			final List<Integer> vetSpecialtiesIds = this.namedParameterJdbcTemplate.query(
+					"SELECT specialty_id FROM vet_specialties WHERE vet_id=:id",
+					vet_params,
+					new BeanPropertyRowMapper<Integer>() {
+						@Override
+						public Integer mapRow(ResultSet rs, int row) throws SQLException {
+							return rs.getInt(1);
+						}
+					});
+			for (int specialtyId : vetSpecialtiesIds) {
+				Specialty specialty = EntityUtils.getById(specialties, Specialty.class, specialtyId);
+				vet.addSpecialty(specialty);
+			}
+
+		} catch (EmptyResultDataAccessException ex) {
+			throw new ObjectRetrievalFailureException(Vet.class, id);
+		}
+		return vet;
 	}
 
 	@Override
 	public void save(Vet vet) throws DataAccessException {
-        BeanPropertySqlParameterSource parameterSource = new BeanPropertySqlParameterSource(vet);
-        if (vet.isNew()) {
-            Number newKey = this.insertVet.executeAndReturnKey(parameterSource);
-            vet.setId(newKey.intValue());
-        } else {
-            this.namedParameterJdbcTemplate.update(
-                "UPDATE vets SET first_name=:firstName, last_name=:lastName WHERE id=:id",
-                parameterSource);
-        }
+		BeanPropertySqlParameterSource parameterSource = new BeanPropertySqlParameterSource(vet);
+		if (vet.isNew()) {
+			Number newKey = this.insertVet.executeAndReturnKey(parameterSource);
+			vet.setId(newKey.intValue());
+		} else {
+			this.namedParameterJdbcTemplate
+					.update("UPDATE vets SET first_name=:firstName, last_name=:lastName WHERE id=:id", parameterSource);
+		}
 	}
 
 	@Override
 	public void delete(Vet vet) throws DataAccessException {
 		Map<String, Object> params = new HashMap<>();
-        params.put("id", vet.getId());
-        this.namedParameterJdbcTemplate.update("DELETE FROM vets WHERE id=:id", params);
+		params.put("id", vet.getId());
+		this.namedParameterJdbcTemplate.update("DELETE FROM vets WHERE id=:id", params);
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVetRepositoryExtImpl.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @Qualifier("VetRepositoryExt")
-public class JdbcVetRepositoryImplExt extends JdbcVetRepositoryImpl implements VetRepositoryExt {
+public class JdbcVetRepositoryExtImpl extends JdbcVetRepositoryImpl implements VetRepositoryExt {
 	
 	//private JdbcTemplate jdbcTemplate;
 	
@@ -31,7 +31,7 @@ public class JdbcVetRepositoryImplExt extends JdbcVetRepositoryImpl implements V
     private SimpleJdbcInsert insertVet;
 
 	@Autowired
-	public JdbcVetRepositoryImplExt(DataSource dataSource, JdbcTemplate jdbcTemplate) {
+	public JdbcVetRepositoryExtImpl(DataSource dataSource, JdbcTemplate jdbcTemplate) {
 		super(jdbcTemplate);
 		// TODO Auto-generated constructor stub
 		//this.jdbcTemplate = jdbcTemplate;

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVetRepositoryExtImpl.java
@@ -15,7 +15,6 @@ import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.orm.ObjectRetrievalFailureException;
-import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.repository.VetRepositoryExt;
 import org.springframework.stereotype.Repository;
@@ -24,8 +23,6 @@ import org.springframework.stereotype.Repository;
 @Qualifier("VetRepositoryExt")
 public class JdbcVetRepositoryExtImpl extends JdbcVetRepositoryImpl implements VetRepositoryExt {
 	
-	//private JdbcTemplate jdbcTemplate;
-	
     private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     private SimpleJdbcInsert insertVet;
@@ -33,13 +30,9 @@ public class JdbcVetRepositoryExtImpl extends JdbcVetRepositoryImpl implements V
 	@Autowired
 	public JdbcVetRepositoryExtImpl(DataSource dataSource, JdbcTemplate jdbcTemplate) {
 		super(jdbcTemplate);
-		// TODO Auto-generated constructor stub
-		//this.jdbcTemplate = jdbcTemplate;
-		
         this.insertVet = new SimpleJdbcInsert(dataSource)
                 .withTableName("vets")
                 .usingGeneratedKeyColumns("id");
-        
         this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVetRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVetRepositoryImpl.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -43,6 +44,7 @@ import org.springframework.stereotype.Repository;
  * @author Michael Isvy
  */
 @Repository
+@Qualifier("VetRepository")
 public class JdbcVetRepositoryImpl implements VetRepository {
 
     private JdbcTemplate jdbcTemplate;

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVetRepositoryImplExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVetRepositoryImplExt.java
@@ -1,0 +1,82 @@
+package org.springframework.samples.petclinic.repository.jdbc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.orm.ObjectRetrievalFailureException;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.model.Vet;
+import org.springframework.samples.petclinic.repository.VetRepositoryExt;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Qualifier("VetRepositoryExt")
+public class JdbcVetRepositoryImplExt extends JdbcVetRepositoryImpl implements VetRepositoryExt {
+	
+	//private JdbcTemplate jdbcTemplate;
+	
+    private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    private SimpleJdbcInsert insertVet;
+
+	@Autowired
+	public JdbcVetRepositoryImplExt(DataSource dataSource, JdbcTemplate jdbcTemplate) {
+		super(jdbcTemplate);
+		// TODO Auto-generated constructor stub
+		//this.jdbcTemplate = jdbcTemplate;
+		
+        this.insertVet = new SimpleJdbcInsert(dataSource)
+                .withTableName("vets")
+                .usingGeneratedKeyColumns("id");
+        
+        this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+	}
+
+	@Override
+	public Vet findById(int id) throws DataAccessException {
+        Vet vet;
+        try {
+            Map<String, Object> params = new HashMap<>();
+            params.put("id", id);
+            vet = this.namedParameterJdbcTemplate.queryForObject(
+                "SELECT id, first_name, last_name FROM vets WHERE id= :id",
+                params,
+                BeanPropertyRowMapper.newInstance(Vet.class));
+        } catch (EmptyResultDataAccessException ex) {
+            throw new ObjectRetrievalFailureException(Vet.class, id);
+        }
+        return vet;
+	}
+
+	@Override
+	public void save(Vet vet) throws DataAccessException {
+        BeanPropertySqlParameterSource parameterSource = new BeanPropertySqlParameterSource(vet);
+        if (vet.isNew()) {
+            Number newKey = this.insertVet.executeAndReturnKey(parameterSource);
+            vet.setId(newKey.intValue());
+        } else {
+            this.namedParameterJdbcTemplate.update(
+                "UPDATE vets SET first_name=:firstName, last_name=:lastName WHERE id=:id",
+                parameterSource);
+        }
+	}
+
+	@Override
+	public void delete(Vet vet) throws DataAccessException {
+		Map<String, Object> params = new HashMap<>();
+        params.put("id", vet.getId());
+        this.namedParameterJdbcTemplate.update("DELETE FROM vets WHERE id=:id", params);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryExtImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.jdbc;
 
 import java.sql.ResultSet;
@@ -19,6 +35,11 @@ import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.VisitRepositoryExt;
 import org.springframework.stereotype.Repository;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Repository
 @Qualifier("VisitRepositoryExt")

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryExtImpl.java
@@ -19,12 +19,12 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @Qualifier("VisitRepositoryExt")
-public class JdbcVisitRepositoryImplExt extends JdbcVisitRepositoryImpl implements VisitRepositoryExt {
+public class JdbcVisitRepositoryExtImpl extends JdbcVisitRepositoryImpl implements VisitRepositoryExt {
 	
 	private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
 	@Autowired
-	public JdbcVisitRepositoryImplExt(DataSource dataSource) {
+	public JdbcVisitRepositoryExtImpl(DataSource dataSource) {
 		super(dataSource);
 		// TODO Auto-generated constructor stub
 		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryExtImpl.java
@@ -1,6 +1,9 @@
 package org.springframework.samples.petclinic.repository.jdbc;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.samples.petclinic.model.Visit;
@@ -21,12 +24,11 @@ import org.springframework.stereotype.Repository;
 @Qualifier("VisitRepositoryExt")
 public class JdbcVisitRepositoryExtImpl extends JdbcVisitRepositoryImpl implements VisitRepositoryExt {
 	
-	private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
-
+	protected NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+	
 	@Autowired
 	public JdbcVisitRepositoryExtImpl(DataSource dataSource) {
 		super(dataSource);
-		// TODO Auto-generated constructor stub
 		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
 	}
 
@@ -37,9 +39,9 @@ public class JdbcVisitRepositoryExtImpl extends JdbcVisitRepositoryImpl implemen
             Map<String, Object> params = new HashMap<>();
             params.put("id", id);
             visit = this.namedParameterJdbcTemplate.queryForObject(
-                "SELECT id, pet_id, visit_date, description FROM visits WHERE id= :id",
+                "SELECT id as visit_id, pet_id, visit_date, description FROM visits WHERE id= :id",
                 params,
-                BeanPropertyRowMapper.newInstance(Visit.class));
+                new JdbcVisitRowMapperExt());
         } catch (EmptyResultDataAccessException ex) {
             throw new ObjectRetrievalFailureException(Visit.class, id);
         }
@@ -49,11 +51,24 @@ public class JdbcVisitRepositoryExtImpl extends JdbcVisitRepositoryImpl implemen
 	@Override
 	public Collection<Visit> findAll() throws DataAccessException {
 		Map<String, Object> params = new HashMap<>();
-        return this.namedParameterJdbcTemplate.query(
-            "SELECT id, pet_id, visit_date, description FROM visits",
+		return this.namedParameterJdbcTemplate.query(
+            "SELECT id as visit_id, pets.id as pet_id, visit_date, description FROM visits LEFT JOIN pets ON visits.pet_id = pets.id",
             params,
-            BeanPropertyRowMapper.newInstance(Visit.class));
+            new JdbcVisitRowMapperExt());
 	}
+	
+    @Override
+    public void save(Visit visit) throws DataAccessException {
+        if (visit.isNew()) {
+            Number newKey = this.insertVisit.executeAndReturnKey(
+                createVisitParameterSource(visit));
+            visit.setId(newKey.intValue());
+        } else {
+        	this.namedParameterJdbcTemplate.update(
+                    "UPDATE visits SET visit_date=:visit_date, description=:description, pet_id=:pet_id WHERE id=:id ",
+                    createVisitParameterSource(visit));
+        }
+    }
 
 	@Override
 	public void delete(Visit visit) throws DataAccessException {
@@ -61,5 +76,25 @@ public class JdbcVisitRepositoryExtImpl extends JdbcVisitRepositoryImpl implemen
         params.put("id", visit.getId());
         this.namedParameterJdbcTemplate.update("DELETE FROM visits WHERE id=:id", params);
 	}
-
+	
+	protected class JdbcVisitRowMapperExt implements RowMapper<Visit>{
+		
+		@Override
+		public Visit mapRow(ResultSet rs, int rowNum) throws SQLException {
+			Visit visit = new Visit();
+			JdbcPet pet = new JdbcPet();
+			visit.setId(rs.getInt("visit_id"));
+		    Date visitDate = rs.getDate("visit_date");
+		    visit.setDate(new Date(visitDate.getTime()));
+		    visit.setDescription(rs.getString("description"));
+		    Map<String, Object> params = new HashMap<>();
+	        params.put("id", rs.getInt("pet_id"));
+	        pet = JdbcVisitRepositoryExtImpl.this.namedParameterJdbcTemplate.
+	        			queryForObject("SELECT pets.id, name, birth_date, type_id, owner_id FROM pets WHERE pets.id=:id",
+	            		params,
+	            		new JdbcPetRowMapper());
+	        visit.setPet(pet);
+		    return visit;
+		}
+	}
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
@@ -16,6 +16,7 @@
 package org.springframework.samples.petclinic.repository.jdbc;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -42,6 +43,7 @@ import java.util.Map;
  * @author Michael Isvy
  */
 @Repository
+@Qualifier("VisitRepository")
 public class JdbcVisitRepositoryImpl implements VisitRepository {
 
     private NamedParameterJdbcTemplate jdbcTemplate;

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
@@ -48,7 +48,7 @@ public class JdbcVisitRepositoryImpl implements VisitRepository {
 
     private NamedParameterJdbcTemplate jdbcTemplate;
 
-    private SimpleJdbcInsert insertVisit;
+    protected SimpleJdbcInsert insertVisit;
 
     @Autowired
     public JdbcVisitRepositoryImpl(DataSource dataSource) {
@@ -75,7 +75,7 @@ public class JdbcVisitRepositoryImpl implements VisitRepository {
     /**
      * Creates a {@link MapSqlParameterSource} based on data values from the supplied {@link Visit} instance.
      */
-    private MapSqlParameterSource createVisitParameterSource(Visit visit) {
+    protected MapSqlParameterSource createVisitParameterSource(Visit visit) {
         return new MapSqlParameterSource()
             .addValue("id", visit.getId())
             .addValue("visit_date", visit.getDate())

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImplExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImplExt.java
@@ -1,0 +1,65 @@
+package org.springframework.samples.petclinic.repository.jdbc;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.orm.ObjectRetrievalFailureException;
+import org.springframework.samples.petclinic.model.Visit;
+import org.springframework.samples.petclinic.repository.VisitRepositoryExt;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Qualifier("VisitRepositoryExt")
+public class JdbcVisitRepositoryImplExt extends JdbcVisitRepositoryImpl implements VisitRepositoryExt {
+	
+	private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+	@Autowired
+	public JdbcVisitRepositoryImplExt(DataSource dataSource) {
+		super(dataSource);
+		// TODO Auto-generated constructor stub
+		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+	}
+
+	@Override
+	public Visit findById(int id) throws DataAccessException {
+		Visit visit;
+        try {
+            Map<String, Object> params = new HashMap<>();
+            params.put("id", id);
+            visit = this.namedParameterJdbcTemplate.queryForObject(
+                "SELECT id, pet_id, visit_date, description FROM visits WHERE id= :id",
+                params,
+                BeanPropertyRowMapper.newInstance(Visit.class));
+        } catch (EmptyResultDataAccessException ex) {
+            throw new ObjectRetrievalFailureException(Visit.class, id);
+        }
+        return visit;
+	}
+
+	@Override
+	public Collection<Visit> findAll() throws DataAccessException {
+		Map<String, Object> params = new HashMap<>();
+        return this.namedParameterJdbcTemplate.query(
+            "SELECT id, pet_id, visit_date, description FROM visits",
+            params,
+            BeanPropertyRowMapper.newInstance(Visit.class));
+	}
+
+	@Override
+	public void delete(Visit visit) throws DataAccessException {
+		Map<String, Object> params = new HashMap<>();
+        params.put("id", visit.getId());
+        this.namedParameterJdbcTemplate.update("DELETE FROM visits WHERE id=:id", params);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryExtImpl.java
@@ -22,18 +22,13 @@ public class JpaOwnerRepositoryExtImpl extends JpaOwnerRepositoryImpl implements
 	@SuppressWarnings("unchecked")
 	@Override
 	public Collection<Owner> findAll() throws DataAccessException {
-		// TODO Select only owner or still join with pets ?
-		Query query = this.em.createQuery("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets");
+		Query query = this.em.createQuery("SELECT owner FROM Owner owner");
         return query.getResultList();
 	}
 
 	@Override
 	public void delete(Owner owner) throws DataAccessException {
-		// TODO need null check, throw Exception etc ?
-		if(!(owner.getId() == null)){
-			this.em.remove(owner);
-		}
-
+		this.em.remove(this.em.contains(owner) ? owner : this.em.merge(owner));
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryExtImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.jpa;
 
 import java.util.Collection;
@@ -11,6 +27,11 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.repository.OwnerRepositoryExt;
 import org.springframework.stereotype.Repository;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Repository
 @Qualifier("OwnerRepositoryExt")

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryExtImpl.java
@@ -1,0 +1,39 @@
+package org.springframework.samples.petclinic.repository.jpa;
+
+import java.util.Collection;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.repository.OwnerRepositoryExt;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Qualifier("OwnerRepositoryExt")
+public class JpaOwnerRepositoryExtImpl extends JpaOwnerRepositoryImpl implements OwnerRepositoryExt {
+	
+    @PersistenceContext
+    private EntityManager em;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Collection<Owner> findAll() throws DataAccessException {
+		// TODO Select only owner or still join with pets ?
+		Query query = this.em.createQuery("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets");
+        return query.getResultList();
+	}
+
+	@Override
+	public void delete(Owner owner) throws DataAccessException {
+		// TODO need null check, throw Exception etc ?
+		if(!(owner.getId() == null)){
+			this.em.remove(owner);
+		}
+
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryImpl.java
@@ -21,6 +21,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.orm.hibernate3.support.OpenSessionInViewFilter;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.repository.OwnerRepository;
@@ -36,6 +37,7 @@ import org.springframework.stereotype.Repository;
  * @since 22.4.2006
  */
 @Repository
+@Qualifier("OwnerRepository")
 public class JpaOwnerRepositoryImpl implements OwnerRepository {
 
     @PersistenceContext

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryExtImpl.java
@@ -4,13 +4,16 @@
 package org.springframework.samples.petclinic.repository.jpa;
 
 import java.util.Collection;
+import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.PetRepositoryExt;
 import org.springframework.stereotype.Repository;
 
@@ -33,7 +36,9 @@ public class JpaPetRepositoryExtImpl extends JpaPetRepositoryImpl implements Pet
 
 	@Override
 	public void delete(Pet pet) throws DataAccessException {
-		this.em.remove(this.em.contains(pet) ? pet : this.em.merge(pet));
+		String petId = pet.getId().toString();
+		this.em.createQuery("DELETE FROM Visit visit WHERE pet_id=" + petId).executeUpdate();
+		this.em.createQuery("DELETE FROM Pet pet WHERE id=" + petId).executeUpdate();
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryExtImpl.java
@@ -1,0 +1,39 @@
+/**
+ * 
+ */
+package org.springframework.samples.petclinic.repository.jpa;
+
+import java.util.Collection;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.repository.PetRepositoryExt;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
+@Repository
+@Qualifier("PetRepositoryExt")
+public class JpaPetRepositoryExtImpl extends JpaPetRepositoryImpl implements PetRepositoryExt {
+	
+    @PersistenceContext
+    private EntityManager em;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Collection<Pet> findAll() throws DataAccessException {
+		return this.em.createQuery("SELECT pet FROM Pet pet").getResultList();
+	}
+
+	@Override
+	public void delete(Pet pet) throws DataAccessException {
+		this.em.remove(pet);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryExtImpl.java
@@ -1,19 +1,29 @@
-/**
- * 
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.springframework.samples.petclinic.repository.jpa;
 
 import java.util.Collection;
-import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
-import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
-import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.PetRepositoryExt;
 import org.springframework.stereotype.Repository;
 
@@ -36,9 +46,13 @@ public class JpaPetRepositoryExtImpl extends JpaPetRepositoryImpl implements Pet
 
 	@Override
 	public void delete(Pet pet) throws DataAccessException {
+		//this.em.remove(this.em.contains(pet) ? pet : this.em.merge(pet));
 		String petId = pet.getId().toString();
 		this.em.createQuery("DELETE FROM Visit visit WHERE pet_id=" + petId).executeUpdate();
 		this.em.createQuery("DELETE FROM Pet pet WHERE id=" + petId).executeUpdate();
+		if (em.contains(pet)) {
+			em.remove(pet);
+		}
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryExtImpl.java
@@ -33,7 +33,7 @@ public class JpaPetRepositoryExtImpl extends JpaPetRepositoryImpl implements Pet
 
 	@Override
 	public void delete(Pet pet) throws DataAccessException {
-		this.em.remove(pet);
+		this.em.remove(this.em.contains(pet) ? pet : this.em.merge(pet));
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryImpl.java
@@ -20,6 +20,7 @@ import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.repository.PetRepository;
@@ -35,6 +36,7 @@ import org.springframework.stereotype.Repository;
  * @since 22.4.2006
  */
 @Repository
+@Qualifier("PetRepository")
 public class JpaPetRepositoryImpl implements PetRepository {
 
     @PersistenceContext

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetTypeRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetTypeRepositoryExtImpl.java
@@ -41,8 +41,7 @@ public class JpaPetTypeRepositoryExtImpl implements PetTypeRepositoryExt {
 
 	@Override
 	public void delete(PetType petType) throws DataAccessException {
-		this.em.remove(petType);
-
+		this.em.remove(this.em.contains(petType) ? petType : this.em.merge(petType));
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetTypeRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetTypeRepositoryExtImpl.java
@@ -1,0 +1,48 @@
+package org.springframework.samples.petclinic.repository.jpa;
+
+import java.util.Collection;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.repository.PetTypeRepositoryExt;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Qualifier("PetTypeRepositoryExt")
+public class JpaPetTypeRepositoryExtImpl implements PetTypeRepositoryExt {
+	
+    @PersistenceContext
+    private EntityManager em;
+
+	@Override
+	public PetType findById(int id) {
+		return this.em.find(PetType.class, id);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Collection<PetType> findAll() throws DataAccessException {
+		return this.em.createQuery("SELECT ptype FROM PetType ptype").getResultList();
+	}
+
+	@Override
+	public void save(PetType petType) throws DataAccessException {
+		if (petType.getId() == null) {
+            this.em.persist(petType);
+        } else {
+            this.em.merge(petType);
+        }
+
+	}
+
+	@Override
+	public void delete(PetType petType) throws DataAccessException {
+		this.em.remove(petType);
+
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetTypeRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetTypeRepositoryExtImpl.java
@@ -1,15 +1,40 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.jpa;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.PetTypeRepositoryExt;
 import org.springframework.stereotype.Repository;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Repository
 @Qualifier("PetTypeRepositoryExt")
@@ -39,9 +64,26 @@ public class JpaPetTypeRepositoryExtImpl implements PetTypeRepositoryExt {
 
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void delete(PetType petType) throws DataAccessException {
-		this.em.remove(this.em.contains(petType) ? petType : this.em.merge(petType));
+		//this.em.remove(this.em.contains(petType) ? petType : this.em.merge(petType));
+		String petTypeId = petType.getId().toString();
+		
+		List<Pet> pets = new ArrayList<Pet>();
+		pets = this.em.createQuery("SELECT pet FROM Pet pet WHERE type_id=" + petTypeId).getResultList();
+		for (Pet pet : pets){
+			List<Visit> visits = new ArrayList<Visit>();
+			visits = pet.getVisits();
+			for (Visit visit : visits){
+				this.em.createQuery("DELETE FROM Visit visit WHERE id=" + visit.getId().toString()).executeUpdate();
+			}
+			this.em.createQuery("DELETE FROM Pet pet WHERE id=" + pet.getId().toString()).executeUpdate();
+		}
+		this.em.createQuery("DELETE FROM PetType pettype WHERE id=" + petTypeId).executeUpdate();
+		if (em.contains(petType)) {
+			em.remove(petType);
+		}
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaSpecialtyRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaSpecialtyRepositoryExtImpl.java
@@ -1,0 +1,44 @@
+package org.springframework.samples.petclinic.repository.jpa;
+
+import java.util.Collection;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Specialty;
+import org.springframework.samples.petclinic.repository.SpecialtyRepositoryExt;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JpaSpecialtyRepositoryExtImpl implements SpecialtyRepositoryExt {
+	
+    @PersistenceContext
+    private EntityManager em;
+
+	@Override
+	public Specialty findById(int id) {
+		return this.em.find(Specialty.class, id);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Collection<Specialty> findAll() throws DataAccessException {
+		return this.em.createQuery("SELECT s FROM Specialty s").getResultList();
+	}
+
+	@Override
+	public void save(Specialty specialty) throws DataAccessException {
+		if (specialty.getId() == null) {
+            this.em.persist(specialty);
+        } else {
+            this.em.merge(specialty);
+        }
+	}
+
+	@Override
+	public void delete(Specialty specialty) throws DataAccessException {
+		this.em.remove(specialty);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaSpecialtyRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaSpecialtyRepositoryExtImpl.java
@@ -40,7 +40,7 @@ public class JpaSpecialtyRepositoryExtImpl implements SpecialtyRepositoryExt {
 
 	@Override
 	public void delete(Specialty specialty) throws DataAccessException {
-		this.em.remove(specialty);
+		this.em.remove(this.em.contains(specialty) ? specialty : this.em.merge(specialty));
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaSpecialtyRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaSpecialtyRepositoryExtImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.jpa;
 
 import java.util.Collection;
@@ -10,6 +26,11 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Specialty;
 import org.springframework.samples.petclinic.repository.SpecialtyRepositoryExt;
 import org.springframework.stereotype.Repository;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Repository
 @Qualifier("SpecialtyRepositoryExt")
@@ -40,7 +61,13 @@ public class JpaSpecialtyRepositoryExtImpl implements SpecialtyRepositoryExt {
 
 	@Override
 	public void delete(Specialty specialty) throws DataAccessException {
-		this.em.remove(this.em.contains(specialty) ? specialty : this.em.merge(specialty));
+		//this.em.remove(this.em.contains(specialty) ? specialty : this.em.merge(specialty));
+		String specId = specialty.getId().toString();
+		this.em.createNativeQuery("DELETE FROM vet_specialties WHERE specialty_id=" + specId).executeUpdate();
+		this.em.createQuery("DELETE FROM Specialty specialty WHERE id=" + specId).executeUpdate();
+		if (em.contains(specialty)) {
+			em.remove(specialty);
+		}
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVetRepositoryExtImpl.java
@@ -40,7 +40,7 @@ public class JpaVetRepositoryExtImpl extends JpaVetRepositoryImpl implements Vet
 
 	@Override
 	public void delete(Vet vet) throws DataAccessException {
-		this.em.remove(vet);
+		this.em.remove(this.em.contains(vet) ? vet : this.em.merge(vet));
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVetRepositoryExtImpl.java
@@ -1,0 +1,46 @@
+package org.springframework.samples.petclinic.repository.jpa;
+
+import java.util.Collection;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Vet;
+import org.springframework.samples.petclinic.repository.VetRepositoryExt;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Qualifier("VetRepositoryExt")
+public class JpaVetRepositoryExtImpl extends JpaVetRepositoryImpl implements VetRepositoryExt {
+	
+    @PersistenceContext
+    private EntityManager em;
+
+	@Override
+	public Vet findById(int id) throws DataAccessException {
+		return this.em.find(Vet.class, id);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Collection<Vet> findAll() throws DataAccessException {
+		return this.em.createQuery("SELECT vet FROM Vet vet").getResultList();
+	}
+
+	@Override
+	public void save(Vet vet) throws DataAccessException {
+        if (vet.getId() == null) {
+            this.em.persist(vet);
+        } else {
+            this.em.merge(vet);
+        }
+	}
+
+	@Override
+	public void delete(Vet vet) throws DataAccessException {
+		this.em.remove(vet);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVetRepositoryExtImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.jpa;
 
 import java.util.Collection;
@@ -10,6 +26,11 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.repository.VetRepositoryExt;
 import org.springframework.stereotype.Repository;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Repository
 @Qualifier("VetRepositoryExt")

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVetRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVetRepositoryImpl.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.samples.petclinic.repository.jpa;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.repository.VetRepository;
 import org.springframework.stereotype.Repository;
@@ -33,6 +34,7 @@ import java.util.Collection;
  * @since 22.4.2006
  */
 @Repository
+@Qualifier("VetRepository")
 public class JpaVetRepositoryImpl implements VetRepository {
 
     @PersistenceContext

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryExtImpl.java
@@ -32,7 +32,8 @@ public class JpaVisitRepositoryExtImpl extends JpaVisitRepositoryImpl implements
 
 	@Override
 	public void delete(Visit visit) throws DataAccessException {
-		this.em.remove(this.em.contains(visit) ? visit : this.em.merge(visit));
+		String visitId = visit.getId().toString();
+		this.em.createQuery("DELETE FROM Visit visit WHERE id=" + visitId).executeUpdate();
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryExtImpl.java
@@ -1,0 +1,39 @@
+package org.springframework.samples.petclinic.repository.jpa;
+
+import java.util.Collection;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Visit;
+import org.springframework.samples.petclinic.repository.VisitRepositoryExt;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Qualifier("VisitRepositoryExt")
+public class JpaVisitRepositoryExtImpl extends JpaVisitRepositoryImpl implements VisitRepositoryExt {
+	
+    @PersistenceContext
+    private EntityManager em;
+
+	@Override
+	public Visit findById(int id) throws DataAccessException {
+		return this.em.find(Visit.class, id);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Collection<Visit> findAll() throws DataAccessException {
+        return this.em.createQuery("SELECT v FROM Visit v").getResultList();
+	}
+
+	@Override
+	public void delete(Visit visit) throws DataAccessException {
+		// TODO Auto-generated method stub
+		this.em.remove(visit);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryExtImpl.java
@@ -32,8 +32,7 @@ public class JpaVisitRepositoryExtImpl extends JpaVisitRepositoryImpl implements
 
 	@Override
 	public void delete(Visit visit) throws DataAccessException {
-		// TODO Auto-generated method stub
-		this.em.remove(visit);
+		this.em.remove(this.em.contains(visit) ? visit : this.em.merge(visit));
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryExtImpl.java
@@ -1,16 +1,36 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.jpa;
 
 import java.util.Collection;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.persistence.Query;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.VisitRepositoryExt;
 import org.springframework.stereotype.Repository;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Repository
 @Qualifier("VisitRepositoryExt")
@@ -34,6 +54,9 @@ public class JpaVisitRepositoryExtImpl extends JpaVisitRepositoryImpl implements
 	public void delete(Visit visit) throws DataAccessException {
 		String visitId = visit.getId().toString();
 		this.em.createQuery("DELETE FROM Visit visit WHERE id=" + visitId).executeUpdate();
+		if (em.contains(visit)) {
+			em.remove(visit);
+		}
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryImpl.java
@@ -21,6 +21,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.VisitRepository;
 import org.springframework.stereotype.Repository;
@@ -37,6 +38,7 @@ import org.springframework.stereotype.Repository;
  * @since 22.4.2006
  */
 @Repository
+@Qualifier("VisitRepository")
 public class JpaVisitRepositoryImpl implements VisitRepository {
 
     @PersistenceContext

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/PetRepositoryExtOverride.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/PetRepositoryExtOverride.java
@@ -1,6 +1,27 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
 import org.springframework.samples.petclinic.model.Pet;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 public interface PetRepositoryExtOverride {
 	

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/PetRepositoryExtOverride.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/PetRepositoryExtOverride.java
@@ -1,0 +1,9 @@
+package org.springframework.samples.petclinic.repository.springdatajpa;
+
+import org.springframework.samples.petclinic.model.Pet;
+
+public interface PetRepositoryExtOverride {
+	
+	public void delete(Pet pet);
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/PetTypeRepositoryExtOverride.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/PetTypeRepositoryExtOverride.java
@@ -16,17 +16,15 @@
 
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.data.repository.Repository;
 import org.springframework.samples.petclinic.model.PetType;
-import org.springframework.samples.petclinic.repository.PetTypeRepositoryExt;
 
 /**
  * @author Vitaliy Fedoriv
  *
  */
 
-@Qualifier("PetTypeRepositoryExt")
-public interface SpringDataPetTypeRepositoryExt extends PetTypeRepositoryExt, Repository<PetType, Integer>, PetTypeRepositoryExtOverride {
+public interface PetTypeRepositoryExtOverride {
+	
+	public void delete(PetType petType);
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpecialtyRepositoryExtOverride.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpecialtyRepositoryExtOverride.java
@@ -16,17 +16,15 @@
 
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.data.repository.Repository;
-import org.springframework.samples.petclinic.model.PetType;
-import org.springframework.samples.petclinic.repository.PetTypeRepositoryExt;
+import org.springframework.samples.petclinic.model.Specialty;
 
 /**
  * @author Vitaliy Fedoriv
  *
  */
 
-@Qualifier("PetTypeRepositoryExt")
-public interface SpringDataPetTypeRepositoryExt extends PetTypeRepositoryExt, Repository<PetType, Integer>, PetTypeRepositoryExtOverride {
+public interface SpecialtyRepositoryExtOverride {
+	
+	public void delete(Specialty specialty);
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepository.java
@@ -17,6 +17,7 @@ package org.springframework.samples.petclinic.repository.springdatajpa;
 
 import java.util.Collection;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -29,6 +30,8 @@ import org.springframework.samples.petclinic.repository.OwnerRepository;
  * @author Michael Isvy
  * @since 15.1.2013
  */
+
+@Qualifier("OwnerRepository")
 public interface SpringDataOwnerRepository extends OwnerRepository, Repository<Owner, Integer> {
 
     @Override

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepositoryExt.java
@@ -1,0 +1,24 @@
+package org.springframework.samples.petclinic.repository.springdatajpa;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.repository.OwnerRepositoryExt;
+
+@Qualifier("OwnerRepositoryExt")
+public interface SpringDataOwnerRepositoryExt extends OwnerRepositoryExt, Repository<Owner, Integer> {
+	
+    @Override
+    @Query("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets WHERE owner.lastName LIKE :lastName%")
+    public Collection<Owner> findByLastName(@Param("lastName") String lastName);
+
+    @Override
+    @Query("SELECT owner FROM Owner owner left join fetch owner.pets WHERE owner.id =:id")
+    public Owner findById(@Param("id") int id);
+    
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepositoryExt.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
 import java.util.Collection;
@@ -8,6 +24,11 @@ import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.repository.OwnerRepositoryExt;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Qualifier("OwnerRepositoryExt")
 public interface SpringDataOwnerRepositoryExt extends OwnerRepositoryExt, Repository<Owner, Integer> {

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepository.java
@@ -17,6 +17,7 @@ package org.springframework.samples.petclinic.repository.springdatajpa;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -30,6 +31,8 @@ import org.springframework.samples.petclinic.repository.PetRepository;
  * @author Michael Isvy
  * @since 15.1.2013
  */
+
+@Qualifier("PetRepository")
 public interface SpringDataPetRepository extends PetRepository, Repository<Pet, Integer> {
 
     @Override

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepositoryExt.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
 import java.util.List;
@@ -9,6 +25,11 @@ import org.springframework.data.repository.Repository;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.repository.PetRepositoryExt;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Qualifier("PetRepositoryExt")
 public interface SpringDataPetRepositoryExt extends PetRepositoryExt, Repository<Pet, Integer>, PetRepositoryExtOverride {

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepositoryExt.java
@@ -1,0 +1,20 @@
+package org.springframework.samples.petclinic.repository.springdatajpa;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.repository.PetRepositoryExt;
+
+@Qualifier("PetRepositoryExt")
+public interface SpringDataPetRepositoryExt extends PetRepositoryExt, Repository<Pet, Integer> {
+	
+    @Override
+    @Query("SELECT ptype FROM PetType ptype ORDER BY ptype.name")
+    List<PetType> findPetTypes() throws DataAccessException;
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepositoryExt.java
@@ -11,7 +11,7 @@ import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.repository.PetRepositoryExt;
 
 @Qualifier("PetRepositoryExt")
-public interface SpringDataPetRepositoryExt extends PetRepositoryExt, Repository<Pet, Integer> {
+public interface SpringDataPetRepositoryExt extends PetRepositoryExt, Repository<Pet, Integer>, PetRepositoryExtOverride {
 	
     @Override
     @Query("SELECT ptype FROM PetType ptype ORDER BY ptype.name")

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepositoryExtImpl.java
@@ -1,0 +1,20 @@
+package org.springframework.samples.petclinic.repository.springdatajpa;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.samples.petclinic.model.Pet;
+
+public class SpringDataPetRepositoryExtImpl implements PetRepositoryExtOverride {
+	
+	@PersistenceContext
+    private EntityManager em;
+
+	@Override
+	public void delete(Pet pet) {
+		String petId = pet.getId().toString();
+		this.em.createQuery("DELETE FROM Visit visit WHERE pet_id=" + petId).executeUpdate();
+		this.em.createQuery("DELETE FROM Pet pet WHERE id=" + petId).executeUpdate();
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepositoryExtImpl.java
@@ -1,9 +1,30 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 import org.springframework.samples.petclinic.model.Pet;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 public class SpringDataPetRepositoryExtImpl implements PetRepositoryExtOverride {
 	

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetTypeRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetTypeRepositoryExt.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.repository.springdatajpa;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.repository.Repository;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.repository.PetTypeRepositoryExt;
+
+@Qualifier("PetTypeRepositoryExt")
+public interface SpringDataPetTypeRepositoryExt extends PetTypeRepositoryExt, Repository<PetType, Integer> {
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetTypeRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetTypeRepositoryExtImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.repository.springdatajpa;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.model.Visit;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
+
+public class SpringDataPetTypeRepositoryExtImpl implements PetTypeRepositoryExtOverride {
+	
+	@PersistenceContext
+    private EntityManager em;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void delete(PetType petType) {
+		String petTypeId = petType.getId().toString();
+		
+		List<Pet> pets = new ArrayList<Pet>();
+		pets = this.em.createQuery("SELECT pet FROM Pet pet WHERE type_id=" + petTypeId).getResultList();
+		for (Pet pet : pets){
+			List<Visit> visits = new ArrayList<Visit>();
+			visits = pet.getVisits();
+			for (Visit visit : visits){
+				this.em.createQuery("DELETE FROM Visit visit WHERE id=" + visit.getId().toString()).executeUpdate();
+			}
+			this.em.createQuery("DELETE FROM Pet pet WHERE id=" + pet.getId().toString()).executeUpdate();
+		}
+		this.em.createQuery("DELETE FROM PetType pettype WHERE id=" + petTypeId).executeUpdate();
+		if (em.contains(petType)) {
+			em.remove(petType);
+		}
+
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataSpecialtyRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataSpecialtyRepositoryExt.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.repository.springdatajpa;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.repository.Repository;
+import org.springframework.samples.petclinic.model.Specialty;
+import org.springframework.samples.petclinic.repository.SpecialtyRepositoryExt;
+
+@Qualifier("SpecialtyRepositoryExt")
+public interface SpringDataSpecialtyRepositoryExt extends SpecialtyRepositoryExt, Repository<Specialty, Integer> {
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataSpecialtyRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataSpecialtyRepositoryExtImpl.java
@@ -16,10 +16,10 @@
 
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.data.repository.Repository;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
 import org.springframework.samples.petclinic.model.Specialty;
-import org.springframework.samples.petclinic.repository.SpecialtyRepositoryExt;
 import org.springframework.samples.petclinic.repository.springdatajpa.SpecialtyRepositoryExtOverride;
 
 /**
@@ -27,7 +27,20 @@ import org.springframework.samples.petclinic.repository.springdatajpa.SpecialtyR
  *
  */
 
-@Qualifier("SpecialtyRepositoryExt")
-public interface SpringDataSpecialtyRepositoryExt extends SpecialtyRepositoryExt, Repository<Specialty, Integer>, SpecialtyRepositoryExtOverride {
+public class SpringDataSpecialtyRepositoryExtImpl implements SpecialtyRepositoryExtOverride {
+	
+	@PersistenceContext
+    private EntityManager em;
+
+	@Override
+	public void delete(Specialty specialty) {
+		String specId = specialty.getId().toString();
+		this.em.createNativeQuery("DELETE FROM vet_specialties WHERE specialty_id=" + specId).executeUpdate();
+		this.em.createQuery("DELETE FROM Specialty specialty WHERE id=" + specId).executeUpdate();
+		if (em.contains(specialty)) {
+			em.remove(specialty);
+		}
+
+	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVetRepository.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.repository.Repository;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.repository.VetRepository;
@@ -25,5 +26,7 @@ import org.springframework.samples.petclinic.repository.VetRepository;
  * @author Michael Isvy
  * @since 15.1.2013
  */
+
+@Qualifier("VetRepository")
 public interface SpringDataVetRepository extends VetRepository, Repository<Vet, Integer> {
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVetRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVetRepositoryExt.java
@@ -1,9 +1,30 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.repository.Repository;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.repository.VetRepositoryExt;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Qualifier("VetRepositoryExt")
 public interface SpringDataVetRepositoryExt extends VetRepositoryExt, Repository<Vet, Integer> {

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVetRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVetRepositoryExt.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.repository.springdatajpa;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.repository.Repository;
+import org.springframework.samples.petclinic.model.Vet;
+import org.springframework.samples.petclinic.repository.VetRepositoryExt;
+
+@Qualifier("VetRepositoryExt")
+public interface SpringDataVetRepositoryExt extends VetRepositoryExt, Repository<Vet, Integer> {
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVisitRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVisitRepository.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.repository.Repository;
 import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.VisitRepository;
@@ -25,5 +26,7 @@ import org.springframework.samples.petclinic.repository.VisitRepository;
  * @author Michael Isvy
  * @since 15.1.2013
  */
+
+@Qualifier("VisitRepository")
 public interface SpringDataVisitRepository extends VisitRepository, Repository<Visit, Integer> {
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVisitRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVisitRepositoryExt.java
@@ -1,9 +1,30 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.repository.Repository;
 import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.VisitRepositoryExt;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Qualifier("VisitRepositoryExt")
 public interface SpringDataVisitRepositoryExt extends VisitRepositoryExt, Repository<Visit, Integer>, VisitRepositoryExtOverride {

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVisitRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVisitRepositoryExt.java
@@ -6,6 +6,6 @@ import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.repository.VisitRepositoryExt;
 
 @Qualifier("VisitRepositoryExt")
-public interface SpringDataVisitRepositoryExt extends VisitRepositoryExt, Repository<Visit, Integer> {
+public interface SpringDataVisitRepositoryExt extends VisitRepositoryExt, Repository<Visit, Integer>, VisitRepositoryExtOverride {
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVisitRepositoryExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVisitRepositoryExt.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.repository.springdatajpa;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.repository.Repository;
+import org.springframework.samples.petclinic.model.Visit;
+import org.springframework.samples.petclinic.repository.VisitRepositoryExt;
+
+@Qualifier("VisitRepositoryExt")
+public interface SpringDataVisitRepositoryExt extends VisitRepositoryExt, Repository<Visit, Integer> {
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVisitRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVisitRepositoryExtImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
 import javax.persistence.EntityManager;
@@ -5,6 +21,11 @@ import javax.persistence.PersistenceContext;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Visit;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 public class SpringDataVisitRepositoryExtImpl implements VisitRepositoryExtOverride {
 	

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVisitRepositoryExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVisitRepositoryExtImpl.java
@@ -1,0 +1,21 @@
+package org.springframework.samples.petclinic.repository.springdatajpa;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Visit;
+
+public class SpringDataVisitRepositoryExtImpl implements VisitRepositoryExtOverride {
+	
+	@PersistenceContext
+    private EntityManager em;
+
+	@Override
+	public void delete(Visit visit) throws DataAccessException {
+		String visitId = visit.getId().toString();
+		this.em.createQuery("DELETE FROM Visit visit WHERE id=" + visitId).executeUpdate();
+	}
+
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/VisitRepositoryExtOverride.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/VisitRepositoryExtOverride.java
@@ -1,6 +1,27 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
 import org.springframework.samples.petclinic.model.Visit;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 public interface VisitRepositoryExtOverride {
 	

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/VisitRepositoryExtOverride.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/VisitRepositoryExtOverride.java
@@ -1,0 +1,9 @@
+package org.springframework.samples.petclinic.repository.springdatajpa;
+
+import org.springframework.samples.petclinic.model.Visit;
+
+public interface VisitRepositoryExtOverride {
+	
+	public void delete(Visit visit);
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/rest/ExceptionControllerAdvice.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/ExceptionControllerAdvice.java
@@ -1,0 +1,14 @@
+package org.springframework.samples.petclinic.rest;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class ExceptionControllerAdvice {
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<Exception> exception(Exception e) {
+		return ResponseEntity.badRequest().body(e);
+	}
+}

--- a/src/main/java/org/springframework/samples/petclinic/rest/ExceptionControllerAdvice.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/ExceptionControllerAdvice.java
@@ -1,8 +1,29 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.rest;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @ControllerAdvice
 public class ExceptionControllerAdvice {

--- a/src/main/java/org/springframework/samples/petclinic/rest/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/OwnerRestController.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.rest;
+
+import java.util.Collection;
+
+import javax.validation.Valid;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.service.ClinicService;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
+
+@RestController
+@RequestMapping("/api/owners")
+public class OwnerRestController {
+	
+	@Autowired
+	private ClinicService clinicService;
+	
+	@RequestMapping(value = "/}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<Collection<Owner>> getAllOwners(){
+		Collection<Owner> owners = this.clinicService.findOwnerByLastName("");
+		if(owners.isEmpty()){
+			return new ResponseEntity<Collection<Owner>>(HttpStatus.NOT_FOUND);
+		}
+		return new ResponseEntity<Collection<Owner>>(owners, HttpStatus.OK);
+	}
+	
+	@RequestMapping(value = "/{ownerId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<Owner> getOwner(@PathVariable("ownerId") int ownerId){
+		Owner owner = this.clinicService.findOwnerById(ownerId);
+		if(owner == null){
+			return new ResponseEntity<Owner>(HttpStatus.NOT_FOUND);
+		}
+		return new ResponseEntity<Owner>(owner, HttpStatus.OK);
+	}
+	
+	@RequestMapping(value = "/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<Void> addOwner(@RequestBody @Valid Owner owner, BindingResult bindingResult, UriComponentsBuilder ucBuilder){
+		if(bindingResult.hasErrors() || (owner == null)){
+			return new ResponseEntity<Void>(HttpStatus.BAD_REQUEST);
+		}
+		this.clinicService.saveOwner(owner);
+		HttpHeaders headers = new HttpHeaders();
+		headers.setLocation(ucBuilder.path("/owners/{id}").buildAndExpand(owner.getId()).toUri());
+		return new ResponseEntity<Void>(headers, HttpStatus.CREATED);
+	}
+	
+	@RequestMapping(value = "/{ownerId}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<Owner> updateOwner(@PathVariable("ownerId") int ownerId, @RequestBody @Valid Owner owner, BindingResult bindingResult, UriComponentsBuilder ucBuilder){
+		if(bindingResult.hasErrors() || (owner == null)){
+			return new ResponseEntity<Owner>(HttpStatus.BAD_REQUEST);
+		}
+		Owner currentOwner = this.clinicService.findOwnerById(ownerId);
+		if(currentOwner == null){
+			return new ResponseEntity<Owner>(HttpStatus.NOT_FOUND);
+		}
+		currentOwner.setAddress(owner.getAddress());
+		currentOwner.setCity(owner.getCity());
+		currentOwner.setFirstName(owner.getFirstName());
+		currentOwner.setLastName(owner.getLastName());;
+		currentOwner.setTelephone(owner.getTelephone());
+		this.clinicService.saveOwner(currentOwner);
+		return new ResponseEntity<Owner>(currentOwner, HttpStatus.OK);
+	}
+
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/rest/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/OwnerRestController.java
@@ -26,7 +26,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.samples.petclinic.model.Owner;
-import org.springframework.samples.petclinic.service.ClinicService;
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.service.ClinicServiceExt;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,7 +47,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class OwnerRestController {
 	
 	@Autowired
-	private ClinicService clinicService;
+	private ClinicServiceExt clinicService;
 	
 	@RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<Collection<Owner>> getOwnersList(@RequestParam("lastName") String ownerLastName){
@@ -96,6 +97,17 @@ public class OwnerRestController {
 		currentOwner.setTelephone(owner.getTelephone());
 		this.clinicService.saveOwner(currentOwner);
 		return new ResponseEntity<Owner>(currentOwner, HttpStatus.NO_CONTENT);
+	}
+	
+	@RequestMapping(value = "/{ownerId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Void> deleteOwner(@PathVariable("ownerId") int ownerId){
+		Owner owner = this.clinicService.findOwnerById(ownerId);
+		if(owner == null){
+			return new ResponseEntity<Void>(HttpStatus.NOT_FOUND);
+		}
+		this.clinicService.deleteOwner(owner);
+		// TODO  delete error - FK etc.
+		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
 	}
 
 

--- a/src/main/java/org/springframework/samples/petclinic/rest/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/OwnerRestController.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -47,16 +48,19 @@ public class OwnerRestController {
 	@Autowired
 	private ClinicService clinicService;
 	
-	@RequestMapping(value = "/}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public ResponseEntity<Collection<Owner>> getAllOwners(){
-		Collection<Owner> owners = this.clinicService.findOwnerByLastName("");
+	@RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Collection<Owner>> getOwnersList(@RequestParam("lastName") String ownerLastName){
+		if (ownerLastName == null){
+			ownerLastName = "";
+		}
+		Collection<Owner> owners = this.clinicService.findOwnerByLastName(ownerLastName);
 		if(owners.isEmpty()){
 			return new ResponseEntity<Collection<Owner>>(HttpStatus.NOT_FOUND);
 		}
 		return new ResponseEntity<Collection<Owner>>(owners, HttpStatus.OK);
 	}
 	
-	@RequestMapping(value = "/{ownerId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@RequestMapping(value = "/{ownerId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<Owner> getOwner(@PathVariable("ownerId") int ownerId){
 		Owner owner = this.clinicService.findOwnerById(ownerId);
 		if(owner == null){
@@ -65,18 +69,18 @@ public class OwnerRestController {
 		return new ResponseEntity<Owner>(owner, HttpStatus.OK);
 	}
 	
-	@RequestMapping(value = "/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+	@RequestMapping(value = "/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<Void> addOwner(@RequestBody @Valid Owner owner, BindingResult bindingResult, UriComponentsBuilder ucBuilder){
 		if(bindingResult.hasErrors() || (owner == null)){
 			return new ResponseEntity<Void>(HttpStatus.BAD_REQUEST);
 		}
 		this.clinicService.saveOwner(owner);
 		HttpHeaders headers = new HttpHeaders();
-		headers.setLocation(ucBuilder.path("/owners/{id}").buildAndExpand(owner.getId()).toUri());
+		headers.setLocation(ucBuilder.path("/api/owners/{id}").buildAndExpand(owner.getId()).toUri());
 		return new ResponseEntity<Void>(headers, HttpStatus.CREATED);
 	}
 	
-	@RequestMapping(value = "/{ownerId}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
+	@RequestMapping(value = "/{ownerId}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<Owner> updateOwner(@PathVariable("ownerId") int ownerId, @RequestBody @Valid Owner owner, BindingResult bindingResult, UriComponentsBuilder ucBuilder){
 		if(bindingResult.hasErrors() || (owner == null)){
 			return new ResponseEntity<Owner>(HttpStatus.BAD_REQUEST);
@@ -91,7 +95,7 @@ public class OwnerRestController {
 		currentOwner.setLastName(owner.getLastName());;
 		currentOwner.setTelephone(owner.getTelephone());
 		this.clinicService.saveOwner(currentOwner);
-		return new ResponseEntity<Owner>(currentOwner, HttpStatus.OK);
+		return new ResponseEntity<Owner>(currentOwner, HttpStatus.NO_CONTENT);
 	}
 
 

--- a/src/main/java/org/springframework/samples/petclinic/rest/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/OwnerRestController.java
@@ -18,6 +18,7 @@ package org.springframework.samples.petclinic.rest;
 
 import java.util.Collection;
 
+import javax.transaction.Transactional;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,14 +27,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.samples.petclinic.model.Owner;
-import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.service.ClinicServiceExt;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -49,12 +48,21 @@ public class OwnerRestController {
 	@Autowired
 	private ClinicServiceExt clinicService;
 	
-	@RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-	public ResponseEntity<Collection<Owner>> getOwnersList(@RequestParam("lastName") String ownerLastName){
+	@RequestMapping(value = "/*/lastname/{lastName}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Collection<Owner>> getOwnersList(@PathVariable("lastName") String ownerLastName){
 		if (ownerLastName == null){
 			ownerLastName = "";
 		}
 		Collection<Owner> owners = this.clinicService.findOwnerByLastName(ownerLastName);
+		if(owners.isEmpty()){
+			return new ResponseEntity<Collection<Owner>>(HttpStatus.NOT_FOUND);
+		}
+		return new ResponseEntity<Collection<Owner>>(owners, HttpStatus.OK);
+	}
+	
+	@RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Collection<Owner>> getOwners(){
+		Collection<Owner> owners = this.clinicService.findAllOwners();
 		if(owners.isEmpty()){
 			return new ResponseEntity<Collection<Owner>>(HttpStatus.NOT_FOUND);
 		}
@@ -100,6 +108,7 @@ public class OwnerRestController {
 	}
 	
 	@RequestMapping(value = "/{ownerId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	@Transactional
 	public ResponseEntity<Void> deleteOwner(@PathVariable("ownerId") int ownerId){
 		Owner owner = this.clinicService.findOwnerById(ownerId);
 		if(owner == null){

--- a/src/main/java/org/springframework/samples/petclinic/rest/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/OwnerRestController.java
@@ -71,7 +71,8 @@ public class OwnerRestController {
 	
 	@RequestMapping(value = "/{ownerId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<Owner> getOwner(@PathVariable("ownerId") int ownerId){
-		Owner owner = this.clinicService.findOwnerById(ownerId);
+		Owner owner = null;
+		owner = this.clinicService.findOwnerById(ownerId);
 		if(owner == null){
 			return new ResponseEntity<Owner>(HttpStatus.NOT_FOUND);
 		}
@@ -115,7 +116,6 @@ public class OwnerRestController {
 			return new ResponseEntity<Void>(HttpStatus.NOT_FOUND);
 		}
 		this.clinicService.deleteOwner(owner);
-		// TODO  delete error - FK etc.
 		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/rest/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/PetRestController.java
@@ -60,7 +60,11 @@ public class PetRestController {
 	
 	@RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<Collection<Pet>> getPets(){
-		return new ResponseEntity<Collection<Pet>>(this.clinicService.findAllPets(), HttpStatus.OK);
+		Collection<Pet> pets = this.clinicService.findAllPets();
+		if(pets.isEmpty()){
+			return new ResponseEntity<Collection<Pet>>(HttpStatus.NOT_FOUND);
+		}
+		return new ResponseEntity<Collection<Pet>>(pets, HttpStatus.OK);
 	}
 	
 	@RequestMapping(value = "/pettypes}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)

--- a/src/main/java/org/springframework/samples/petclinic/rest/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/PetRestController.java
@@ -57,6 +57,11 @@ public class PetRestController {
 		return new ResponseEntity<Pet>(pet, HttpStatus.OK);
 	}
 	
+	@RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Collection<Pet>> getPets(){
+		return new ResponseEntity<Collection<Pet>>(this.clinicService.findAllPets(), HttpStatus.OK);
+	}
+	
 	@RequestMapping(value = "/pettypes}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<Collection<PetType>> getPetTypes(){
 		return new ResponseEntity<Collection<PetType>>(this.clinicService.findPetTypes(), HttpStatus.OK);

--- a/src/main/java/org/springframework/samples/petclinic/rest/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/PetRestController.java
@@ -27,7 +27,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
-import org.springframework.samples.petclinic.service.ClinicService;
+import org.springframework.samples.petclinic.service.ClinicServiceExt;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,7 +46,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class PetRestController {
 	
 	@Autowired
-	private ClinicService clinicService;
+	private ClinicServiceExt clinicService;
 	
 	@RequestMapping(value = "/{petId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<Pet> getPet(@PathVariable("petId") int petId){
@@ -87,6 +87,17 @@ public class PetRestController {
 		currentPet.setType(pet.getType());
 		this.clinicService.savePet(currentPet);
 		return new ResponseEntity<Pet>(currentPet, HttpStatus.NO_CONTENT);
+	}
+	
+	@RequestMapping(value = "/{petId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Void> deletePet(@PathVariable("petId") int petId){
+		Pet pet = this.clinicService.findPetById(petId);
+		if(pet == null){
+			return new ResponseEntity<Void>(HttpStatus.NOT_FOUND);
+		}
+		this.clinicService.deletePet(pet);
+		// TODO  delete error - FK etc.
+		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
 	}
 	
 

--- a/src/main/java/org/springframework/samples/petclinic/rest/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/PetRestController.java
@@ -18,6 +18,7 @@ package org.springframework.samples.petclinic.rest;
 
 import java.util.Collection;
 
+import javax.transaction.Transactional;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -95,13 +96,13 @@ public class PetRestController {
 	}
 	
 	@RequestMapping(value = "/{petId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	@Transactional
 	public ResponseEntity<Void> deletePet(@PathVariable("petId") int petId){
 		Pet pet = this.clinicService.findPetById(petId);
 		if(pet == null){
 			return new ResponseEntity<Void>(HttpStatus.NOT_FOUND);
 		}
 		this.clinicService.deletePet(pet);
-		// TODO  delete error - FK etc.
 		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
 	}
 	

--- a/src/main/java/org/springframework/samples/petclinic/rest/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/PetRestController.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.rest;
+
+import java.util.Collection;
+
+import javax.validation.Valid;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.service.ClinicService;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
+
+@RestController
+@RequestMapping("api/pets")
+public class PetRestController {
+	
+	@Autowired
+	private ClinicService clinicService;
+	
+	@RequestMapping(value = "/{petId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Pet> getPet(@PathVariable("petId") int petId){
+		Pet pet = this.clinicService.findPetById(petId);
+		if(pet == null){
+			return new ResponseEntity<Pet>(HttpStatus.NOT_FOUND);
+		}
+		return new ResponseEntity<Pet>(pet, HttpStatus.OK);
+	}
+	
+	@RequestMapping(value = "/pettypes}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Collection<PetType>> getPetTypes(){
+		return new ResponseEntity<Collection<PetType>>(this.clinicService.findPetTypes(), HttpStatus.OK);
+	}
+	
+	@RequestMapping(value = "/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Void> addPet(@RequestBody @Valid Pet pet, BindingResult bindingResult, UriComponentsBuilder ucBuilder){
+		if(bindingResult.hasErrors() || (pet == null)){
+			return new ResponseEntity<Void>(HttpStatus.BAD_REQUEST);
+		}
+		this.clinicService.savePet(pet);
+		HttpHeaders headers = new HttpHeaders();
+		headers.setLocation(ucBuilder.path("/api/pets/{id}").buildAndExpand(pet.getId()).toUri());
+		return new ResponseEntity<Void>(headers, HttpStatus.CREATED);
+	}
+	
+	@RequestMapping(value = "/{petId}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Pet> updatePet(@PathVariable("petId") int petId, @RequestBody @Valid Pet pet, BindingResult bindingResult){
+		if(bindingResult.hasErrors() || (pet == null)){
+			return new ResponseEntity<Pet>(HttpStatus.BAD_REQUEST);
+		}
+		Pet currentPet = this.clinicService.findPetById(petId);
+		if(currentPet == null){
+			return new ResponseEntity<Pet>(HttpStatus.NOT_FOUND);
+		}
+		currentPet.setBirthDate(pet.getBirthDate());
+		currentPet.setName(pet.getName());
+		currentPet.setType(pet.getType());
+		this.clinicService.savePet(currentPet);
+		return new ResponseEntity<Pet>(currentPet, HttpStatus.NO_CONTENT);
+	}
+	
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/rest/PetTypeRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/PetTypeRestController.java
@@ -81,7 +81,6 @@ public class PetTypeRestController {
 			return new ResponseEntity<Void>(HttpStatus.NOT_FOUND);
 		}
 		this.clinicService.deletePetType(petType);
-		// TODO  delete error - FK etc.
 		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/rest/PetTypeRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/PetTypeRestController.java
@@ -3,6 +3,7 @@ package org.springframework.samples.petclinic.rest;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import javax.transaction.Transactional;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,6 +74,7 @@ public class PetTypeRestController {
 	}
 	
 	@RequestMapping(value = "/{petTypeId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	@Transactional
 	public ResponseEntity<Void> deletePetType(@PathVariable("petTypeId") int petTypeId){
 		PetType petType = this.clinicService.findPetTypeById(petTypeId);
 		if(petType == null){

--- a/src/main/java/org/springframework/samples/petclinic/rest/PetTypeRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/PetTypeRestController.java
@@ -1,0 +1,86 @@
+package org.springframework.samples.petclinic.rest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.validation.Valid;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.service.ClinicServiceExt;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RestController
+@RequestMapping("api/pettypes")
+public class PetTypeRestController {
+	
+	@Autowired
+	private ClinicServiceExt clinicService;
+	
+	@RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Collection<PetType>> getAllPetTypes(){
+		Collection<PetType> petTypes = new ArrayList<PetType>();
+		petTypes.addAll(this.clinicService.findAllPetTypes());
+		if (petTypes.isEmpty()){
+			return new ResponseEntity<Collection<PetType>>(HttpStatus.NOT_FOUND);
+		}
+		return new ResponseEntity<Collection<PetType>>(petTypes, HttpStatus.OK);
+	}
+	
+	@RequestMapping(value = "/{petTypeId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<PetType> getPetType(@PathVariable("petTypeId") int petTypeId){
+		PetType petType = this.clinicService.findPetTypeById(petTypeId);
+		if(petType == null){
+			return new ResponseEntity<PetType>(HttpStatus.NOT_FOUND);
+		}
+		return new ResponseEntity<PetType>(petType, HttpStatus.OK);
+	}
+	
+	
+	@RequestMapping(value = "/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Void> addPetType(@RequestBody @Valid PetType petType, BindingResult bindingResult, UriComponentsBuilder ucBuilder){
+		if(bindingResult.hasErrors() || (petType == null)){
+			return new ResponseEntity<Void>(HttpStatus.BAD_REQUEST);
+		}
+		this.clinicService.savePetType(petType);
+		HttpHeaders headers = new HttpHeaders();
+		headers.setLocation(ucBuilder.path("/api/pettypes/{id}").buildAndExpand(petType.getId()).toUri());
+		return new ResponseEntity<Void>(headers, HttpStatus.CREATED);
+	}
+	
+	@RequestMapping(value = "/{petTypeId}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<PetType> updatePetType(@PathVariable("petTypeId") int petTypeId, @RequestBody @Valid PetType petType, BindingResult bindingResult){
+		if(bindingResult.hasErrors() || (petType == null)){
+			return new ResponseEntity<PetType>(HttpStatus.BAD_REQUEST);
+		}
+		PetType currentPetType = this.clinicService.findPetTypeById(petTypeId);
+		if(currentPetType == null){
+			return new ResponseEntity<PetType>(HttpStatus.NOT_FOUND);
+		}
+		currentPetType.setName(petType.getName());
+		this.clinicService.savePetType(currentPetType);
+		return new ResponseEntity<PetType>(currentPetType, HttpStatus.NO_CONTENT);
+	}
+	
+	@RequestMapping(value = "/{petTypeId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Void> deletePetType(@PathVariable("petTypeId") int petTypeId){
+		PetType petType = this.clinicService.findPetTypeById(petTypeId);
+		if(petType == null){
+			return new ResponseEntity<Void>(HttpStatus.NOT_FOUND);
+		}
+		this.clinicService.deletePetType(petType);
+		// TODO  delete error - FK etc.
+		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/rest/SpecialtyRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/SpecialtyRestController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.rest;
 
 import java.util.ArrayList;
@@ -20,6 +36,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @RestController
 @RequestMapping("api/specialties")
@@ -81,7 +102,6 @@ public class SpecialtyRestController {
 			return new ResponseEntity<Void>(HttpStatus.NOT_FOUND);
 		}
 		this.clinicService.deleteSpecialty(specialty);
-		// TODO  delete error - FK etc.
 		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/rest/SpecialtyRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/SpecialtyRestController.java
@@ -1,0 +1,86 @@
+package org.springframework.samples.petclinic.rest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.validation.Valid;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.model.Specialty;
+import org.springframework.samples.petclinic.service.ClinicServiceExt;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RestController
+@RequestMapping("api/specialties")
+public class SpecialtyRestController {
+	
+	@Autowired
+	private ClinicServiceExt clinicService;
+	
+	@RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Collection<Specialty>> getAllSpecialtys(){
+		Collection<Specialty> specialties = new ArrayList<Specialty>();
+		specialties.addAll(this.clinicService.findAllSpecialties());
+		if (specialties.isEmpty()){
+			return new ResponseEntity<Collection<Specialty>>(HttpStatus.NOT_FOUND);
+		}
+		return new ResponseEntity<Collection<Specialty>>(specialties, HttpStatus.OK);
+	}
+	
+	@RequestMapping(value = "/{specialtyId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Specialty> getSpecialty(@PathVariable("specialtyId") int specialtyId){
+		Specialty specialty = this.clinicService.findSpecialtyById(specialtyId);
+		if(specialty == null){
+			return new ResponseEntity<Specialty>(HttpStatus.NOT_FOUND);
+		}
+		return new ResponseEntity<Specialty>(specialty, HttpStatus.OK);
+	}
+	
+	
+	@RequestMapping(value = "/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Void> addSpecialty(@RequestBody @Valid Specialty specialty, BindingResult bindingResult, UriComponentsBuilder ucBuilder){
+		if(bindingResult.hasErrors() || (specialty == null)){
+			return new ResponseEntity<Void>(HttpStatus.BAD_REQUEST);
+		}
+		this.clinicService.saveSpecialty(specialty);
+		HttpHeaders headers = new HttpHeaders();
+		headers.setLocation(ucBuilder.path("/api/specialtys/{id}").buildAndExpand(specialty.getId()).toUri());
+		return new ResponseEntity<Void>(headers, HttpStatus.CREATED);
+	}
+	
+	@RequestMapping(value = "/{specialtyId}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Specialty> updateSpecialty(@PathVariable("specialtyId") int specialtyId, @RequestBody @Valid Specialty specialty, BindingResult bindingResult){
+		if(bindingResult.hasErrors() || (specialty == null)){
+			return new ResponseEntity<Specialty>(HttpStatus.BAD_REQUEST);
+		}
+		Specialty currentSpecialty = this.clinicService.findSpecialtyById(specialtyId);
+		if(currentSpecialty == null){
+			return new ResponseEntity<Specialty>(HttpStatus.NOT_FOUND);
+		}
+		currentSpecialty.setName(specialty.getName());
+		this.clinicService.saveSpecialty(currentSpecialty);
+		return new ResponseEntity<Specialty>(currentSpecialty, HttpStatus.NO_CONTENT);
+	}
+	
+	@RequestMapping(value = "/{specialtyId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Void> deleteSpecialty(@PathVariable("specialtyId") int specialtyId){
+		Specialty specialty = this.clinicService.findSpecialtyById(specialtyId);
+		if(specialty == null){
+			return new ResponseEntity<Void>(HttpStatus.NOT_FOUND);
+		}
+		this.clinicService.deleteSpecialty(specialty);
+		// TODO  delete error - FK etc.
+		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/rest/SpecialtyRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/SpecialtyRestController.java
@@ -3,6 +3,7 @@ package org.springframework.samples.petclinic.rest;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import javax.transaction.Transactional;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,6 +74,7 @@ public class SpecialtyRestController {
 	}
 	
 	@RequestMapping(value = "/{specialtyId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	@Transactional
 	public ResponseEntity<Void> deleteSpecialty(@PathVariable("specialtyId") int specialtyId){
 		Specialty specialty = this.clinicService.findSpecialtyById(specialtyId);
 		if(specialty == null){

--- a/src/main/java/org/springframework/samples/petclinic/rest/VetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/VetRestController.java
@@ -102,7 +102,6 @@ public class VetRestController {
 			return new ResponseEntity<Void>(HttpStatus.NOT_FOUND);
 		}
 		this.clinicService.deleteVet(vet);
-		// TODO  delete error - FK etc.
 		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
 	}
 	

--- a/src/main/java/org/springframework/samples/petclinic/rest/VetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/VetRestController.java
@@ -18,6 +18,7 @@ package org.springframework.samples.petclinic.rest;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import javax.transaction.Transactional;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -94,6 +95,7 @@ public class VetRestController {
 	}
 	
 	@RequestMapping(value = "/{vetId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	@Transactional
 	public ResponseEntity<Void> deleteVet(@PathVariable("vetId") int vetId){
 		Vet vet = this.clinicService.findVetById(vetId);
 		if(vet == null){

--- a/src/main/java/org/springframework/samples/petclinic/rest/VetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/VetRestController.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.rest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.model.Vet;
+import org.springframework.samples.petclinic.service.ClinicService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
+
+@RestController
+@RequestMapping("api/vets")
+public class VetRestController {
+	
+	@Autowired
+	private ClinicService clinicService;
+	
+	@RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<Collection<Vet>> getAllVets(){
+		Collection<Vet> vets = new ArrayList<Vet>();
+		vets.addAll(this.clinicService.findVets());
+		if (vets.isEmpty()){
+			return new ResponseEntity<Collection<Vet>>(HttpStatus.NOT_FOUND);
+		}
+		return new ResponseEntity<Collection<Vet>>(vets, HttpStatus.OK);
+	}
+	
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/rest/VetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/VetRestController.java
@@ -51,7 +51,7 @@ public class VetRestController {
 	@RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<Collection<Vet>> getAllVets(){
 		Collection<Vet> vets = new ArrayList<Vet>();
-		vets.addAll(this.clinicService.findVets());
+		vets.addAll(this.clinicService.findAllVets());
 		if (vets.isEmpty()){
 			return new ResponseEntity<Collection<Vet>>(HttpStatus.NOT_FOUND);
 		}

--- a/src/main/java/org/springframework/samples/petclinic/rest/VetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/VetRestController.java
@@ -40,7 +40,7 @@ public class VetRestController {
 	@Autowired
 	private ClinicService clinicService;
 	
-	@RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<Collection<Vet>> getAllVets(){
 		Collection<Vet> vets = new ArrayList<Vet>();
 		vets.addAll(this.clinicService.findVets());

--- a/src/main/java/org/springframework/samples/petclinic/rest/VisitRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/VisitRestController.java
@@ -50,7 +50,7 @@ public class VisitRestController {
 	
 	@RequestMapping(value = "/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<Void> addVisit(@RequestBody @Valid Visit visit, BindingResult bindingResult, UriComponentsBuilder ucBuilder){
-		if(bindingResult.hasErrors() || (visit == null)){
+		if(bindingResult.hasErrors() || (visit == null) || (visit.getPet() == null)){
 			return new ResponseEntity<Void>(HttpStatus.BAD_REQUEST);
 		}
 		this.clinicService.saveVisit(visit);
@@ -61,7 +61,7 @@ public class VisitRestController {
 	
 	@RequestMapping(value = "/{visitId}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 	public ResponseEntity<Visit> updateVisit(@PathVariable("visitId") int visitId, @RequestBody @Valid Visit visit, BindingResult bindingResult){
-		if(bindingResult.hasErrors() || (visit == null)){
+		if(bindingResult.hasErrors() || (visit == null) || (visit.getPet() == null)){
 			return new ResponseEntity<Visit>(HttpStatus.BAD_REQUEST);
 		}
 		Visit currentVisit = this.clinicService.findVisitById(visitId);

--- a/src/main/java/org/springframework/samples/petclinic/rest/VisitRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/VisitRestController.java
@@ -3,6 +3,7 @@ package org.springframework.samples.petclinic.rest;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import javax.transaction.Transactional;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,6 +76,7 @@ public class VisitRestController {
 	}
 	
 	@RequestMapping(value = "/{visitId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	@Transactional
 	public ResponseEntity<Void> deleteVisit(@PathVariable("visitId") int visitId){
 		Visit visit = this.clinicService.findVisitById(visitId);
 		if(visit == null){

--- a/src/main/java/org/springframework/samples/petclinic/rest/VisitRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/VisitRestController.java
@@ -1,0 +1,88 @@
+package org.springframework.samples.petclinic.rest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.validation.Valid;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.model.Visit;
+import org.springframework.samples.petclinic.service.ClinicServiceExt;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RestController
+@RequestMapping("api/visits")
+public class VisitRestController {
+	
+	@Autowired
+	private ClinicServiceExt clinicService;
+	
+	@RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Collection<Visit>> getAllVisits(){
+		Collection<Visit> visits = new ArrayList<Visit>();
+		visits.addAll(this.clinicService.findAllVisits());
+		if (visits.isEmpty()){
+			return new ResponseEntity<Collection<Visit>>(HttpStatus.NOT_FOUND);
+		}
+		return new ResponseEntity<Collection<Visit>>(visits, HttpStatus.OK);
+	}
+	
+	@RequestMapping(value = "/{visitId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Visit> getVisit(@PathVariable("visitId") int visitId){
+		Visit visit = this.clinicService.findVisitById(visitId);
+		if(visit == null){
+			return new ResponseEntity<Visit>(HttpStatus.NOT_FOUND);
+		}
+		return new ResponseEntity<Visit>(visit, HttpStatus.OK);
+	}
+	
+	
+	@RequestMapping(value = "/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Void> addVisit(@RequestBody @Valid Visit visit, BindingResult bindingResult, UriComponentsBuilder ucBuilder){
+		if(bindingResult.hasErrors() || (visit == null)){
+			return new ResponseEntity<Void>(HttpStatus.BAD_REQUEST);
+		}
+		this.clinicService.saveVisit(visit);
+		HttpHeaders headers = new HttpHeaders();
+		headers.setLocation(ucBuilder.path("/api/visits/{id}").buildAndExpand(visit.getId()).toUri());
+		return new ResponseEntity<Void>(headers, HttpStatus.CREATED);
+	}
+	
+	@RequestMapping(value = "/{visitId}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Visit> updateVisit(@PathVariable("visitId") int visitId, @RequestBody @Valid Visit visit, BindingResult bindingResult){
+		if(bindingResult.hasErrors() || (visit == null)){
+			return new ResponseEntity<Visit>(HttpStatus.BAD_REQUEST);
+		}
+		Visit currentVisit = this.clinicService.findVisitById(visitId);
+		if(currentVisit == null){
+			return new ResponseEntity<Visit>(HttpStatus.NOT_FOUND);
+		}
+		currentVisit.setDate(visit.getDate());
+		currentVisit.setDescription(visit.getDescription());
+		currentVisit.setPet(visit.getPet());
+		this.clinicService.saveVisit(currentVisit);
+		return new ResponseEntity<Visit>(currentVisit, HttpStatus.NO_CONTENT);
+	}
+	
+	@RequestMapping(value = "/{visitId}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+	public ResponseEntity<Void> deleteVisit(@PathVariable("visitId") int visitId){
+		Visit visit = this.clinicService.findVisitById(visitId);
+		if(visit == null){
+			return new ResponseEntity<Void>(HttpStatus.NOT_FOUND);
+		}
+		this.clinicService.deleteVisit(visit);
+		// TODO  delete error - FK etc.
+		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/rest/VisitRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/VisitRestController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.rest;
 
 import java.util.ArrayList;
@@ -20,6 +36,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @RestController
 @RequestMapping("api/visits")
@@ -83,7 +104,6 @@ public class VisitRestController {
 			return new ResponseEntity<Void>(HttpStatus.NOT_FOUND);
 		}
 		this.clinicService.deleteVisit(visit);
-		// TODO  delete error - FK etc.
 		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/rest/package-info.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * The classes in this package represent PetClinic's REST API.
+ */
+
+package org.springframework.samples.petclinic.rest;

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceExt.java
@@ -1,0 +1,49 @@
+package org.springframework.samples.petclinic.service;
+
+import java.util.Collection;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.model.Specialty;
+import org.springframework.samples.petclinic.model.Vet;
+import org.springframework.samples.petclinic.model.Visit;
+
+public interface ClinicServiceExt extends ClinicService {
+
+//  Pet findPetById(int id) throws DataAccessException;
+	Collection<Pet> findAllPets() throws DataAccessException;
+//  void savePet(Pet pet) throws DataAccessException;
+	void deletePet(Pet pet) throws DataAccessException;
+
+//	Collection<Visit> findVisitsByPetId(int petId);
+	Visit findVisitById(int visitId) throws DataAccessException;
+	Collection<Visit> findAllVisits() throws DataAccessException;
+//  void saveVisit(Visit visit) throws DataAccessException;
+	void deleteVisit(Visit visit) throws DataAccessException;
+	
+	Vet findVetById(int id) throws DataAccessException;
+//  Collection<Vet> findVets() throws DataAccessException;
+	Collection<Vet> findAllVets() throws DataAccessException;
+	void saveVet(Vet vet) throws DataAccessException;
+	void deleteVet(Vet vet) throws DataAccessException;
+
+//  Owner findOwnerById(int id) throws DataAccessException;
+	Collection<Owner> findAllOwners() throws DataAccessException;
+//  void saveOwner(Owner owner) throws DataAccessException;
+	void deleteOwner(Owner owner) throws DataAccessException;
+//  Collection<Owner> findOwnerByLastName(String lastName) throws DataAccessException;
+
+	PetType findPetTypeById(int petTypeId);
+	Collection<PetType> findAllPetTypes() throws DataAccessException;
+//  Collection<PetType> findPetTypes() throws DataAccessException;
+	void savePetType(PetType petType) throws DataAccessException;
+	void deletePetType(PetType petType) throws DataAccessException;
+	
+	Specialty findSpecialtyById(int specialtyId);
+	Collection<Specialty> findAllSpecialties() throws DataAccessException;
+	void saveSpecialty(Specialty specialty) throws DataAccessException;
+	void deleteSpecialty(Specialty specialty) throws DataAccessException;
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceExt.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceExt.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.service;
 
 import java.util.Collection;
@@ -10,37 +26,49 @@ import org.springframework.samples.petclinic.model.Specialty;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.model.Visit;
 
+/**
+ * Used as a facade so all (incl.extended) controllers have a single point of entry
+ *
+ * @author Vitaliy Fedoriv
+ */
+
 public interface ClinicServiceExt extends ClinicService {
 
-//  Pet findPetById(int id) throws DataAccessException;
+	//  ----- Pet -----
+	// (in ClinicService)  Pet findPetById(int id) throws DataAccessException;
 	Collection<Pet> findAllPets() throws DataAccessException;
-//  void savePet(Pet pet) throws DataAccessException;
+	// (in ClinicService)  void savePet(Pet pet) throws DataAccessException;
 	void deletePet(Pet pet) throws DataAccessException;
 
-//	Collection<Visit> findVisitsByPetId(int petId);
+	//  ----- Visit -----
+	// (in ClinicService)	Collection<Visit> findVisitsByPetId(int petId);
 	Visit findVisitById(int visitId) throws DataAccessException;
 	Collection<Visit> findAllVisits() throws DataAccessException;
-//  void saveVisit(Visit visit) throws DataAccessException;
+	// (in ClinicService)  void saveVisit(Visit visit) throws DataAccessException;
 	void deleteVisit(Visit visit) throws DataAccessException;
 	
+	//  ----- Vet -----
 	Vet findVetById(int id) throws DataAccessException;
-//  Collection<Vet> findVets() throws DataAccessException;
+	// (in ClinicService)  Collection<Vet> findVets() throws DataAccessException;
 	Collection<Vet> findAllVets() throws DataAccessException;
 	void saveVet(Vet vet) throws DataAccessException;
 	void deleteVet(Vet vet) throws DataAccessException;
-
-//  Owner findOwnerById(int id) throws DataAccessException;
+	
+	//  ----- Owner -----
+	// (in ClinicService)  Owner findOwnerById(int id) throws DataAccessException;
 	Collection<Owner> findAllOwners() throws DataAccessException;
-//  void saveOwner(Owner owner) throws DataAccessException;
+	// (in ClinicService)  void saveOwner(Owner owner) throws DataAccessException;
 	void deleteOwner(Owner owner) throws DataAccessException;
-//  Collection<Owner> findOwnerByLastName(String lastName) throws DataAccessException;
+	// (in ClinicService)  Collection<Owner> findOwnerByLastName(String lastName) throws DataAccessException;
 
+	//  ----- PetType -----
 	PetType findPetTypeById(int petTypeId);
 	Collection<PetType> findAllPetTypes() throws DataAccessException;
-//  Collection<PetType> findPetTypes() throws DataAccessException;
+	// (in ClinicService)  Collection<PetType> findPetTypes() throws DataAccessException;
 	void savePetType(PetType petType) throws DataAccessException;
 	void deletePetType(PetType petType) throws DataAccessException;
 	
+	//  ----- Specialty -----
 	Specialty findSpecialtyById(int specialtyId);
 	Collection<Specialty> findAllSpecialties() throws DataAccessException;
 	void saveSpecialty(Specialty specialty) throws DataAccessException;

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceExtImpl.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
@@ -21,7 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class ClinicServiceExtImpl extends ClinicServiceImpl implements ClinicServiceExt {
+public class ClinicServiceExtImpl implements ClinicServiceExt {
 		
 	private SpecialtyRepositoryExt specialtyRepositoryExt;
 	private PetTypeRepositoryExt petTypeRepositoryExt;
@@ -38,7 +39,6 @@ public class ClinicServiceExtImpl extends ClinicServiceImpl implements ClinicSer
 				@Qualifier("VisitRepositoryExt") VisitRepositoryExt visitRepositoryExt,
 				@Qualifier("SpecialtyRepositoryExt") SpecialtyRepositoryExt specialtyRepositoryExt,
 				@Qualifier("PetTypeRepositoryExt") PetTypeRepositoryExt petTypeRepositoryExt) {
-		super(petRepositoryExt, vetRepositoryExt, ownerRepositoryExt, visitRepositoryExt);
 		this.specialtyRepositoryExt = specialtyRepositoryExt; 
 		this.petTypeRepositoryExt = petTypeRepositoryExt;
 		this.petRepositoryExt = petRepositoryExt;
@@ -159,6 +159,64 @@ public class ClinicServiceExtImpl extends ClinicServiceImpl implements ClinicSer
 	@Transactional
 	public void deleteSpecialty(Specialty specialty) throws DataAccessException {
 		specialtyRepositoryExt.delete(specialty);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Collection<PetType> findPetTypes() throws DataAccessException {
+		return petRepositoryExt.findPetTypes();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Owner findOwnerById(int id) throws DataAccessException {
+		return ownerRepositoryExt.findById(id);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Pet findPetById(int id) throws DataAccessException {
+		return petRepositoryExt.findById(id);
+	}
+
+	@Override
+	@Transactional
+	public void savePet(Pet pet) throws DataAccessException {
+		petRepositoryExt.save(pet);
+		
+	}
+
+	@Override
+	@Transactional
+	public void saveVisit(Visit visit) throws DataAccessException {
+		visitRepositoryExt.save(visit);
+		
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+    @Cacheable(value = "vets")
+	public Collection<Vet> findVets() throws DataAccessException {
+		return vetRepositoryExt.findAll();
+	}
+
+	@Override
+	@Transactional
+	public void saveOwner(Owner owner) throws DataAccessException {
+		ownerRepositoryExt.save(owner);
+		
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Collection<Owner> findOwnerByLastName(String lastName) throws DataAccessException {
+		return ownerRepositoryExt.findByLastName(lastName);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Collection<Visit> findVisitsByPetId(int petId) {
+		return visitRepositoryExt.findByPetId(petId);
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceExtImpl.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Qualifier("ClinicServiceExt")
 public class ClinicServiceExtImpl implements ClinicServiceExt {
 		
 	private SpecialtyRepositoryExt specialtyRepositoryExt;

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceExtImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.service;
 
 import java.util.Collection;
@@ -6,6 +22,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
@@ -20,6 +38,11 @@ import org.springframework.samples.petclinic.repository.VetRepositoryExt;
 import org.springframework.samples.petclinic.repository.VisitRepositoryExt;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Vitaliy Fedoriv
+ *
+ */
 
 @Service
 @Qualifier("ClinicServiceExt")
@@ -63,7 +86,14 @@ public class ClinicServiceExtImpl implements ClinicServiceExt {
 	@Override
 	@Transactional(readOnly = true)
 	public Visit findVisitById(int visitId) throws DataAccessException {
-		return visitRepositoryExt.findById(visitId);
+		Visit visit = null;
+		try {
+			visit = visitRepositoryExt.findById(visitId);
+		} catch (ObjectRetrievalFailureException|EmptyResultDataAccessException e) {
+		// just ignore not found exceptions for Jdbc/Jpa realization
+			return null;
+		}
+		return visit;
 	}
 
 	@Override
@@ -81,7 +111,14 @@ public class ClinicServiceExtImpl implements ClinicServiceExt {
 	@Override
 	@Transactional(readOnly = true)
 	public Vet findVetById(int id) throws DataAccessException {
-		return vetRepositoryExt.findById(id);
+		Vet vet = null;
+		try {
+			vet = vetRepositoryExt.findById(id);
+		} catch (ObjectRetrievalFailureException|EmptyResultDataAccessException e) {
+		// just ignore not found exceptions for Jdbc/Jpa realization
+			return null;
+		}
+		return vet;
 	}
 
 	@Override
@@ -117,7 +154,14 @@ public class ClinicServiceExtImpl implements ClinicServiceExt {
 	@Override
 	@Transactional(readOnly = true)
 	public PetType findPetTypeById(int petTypeId) {
-		return petTypeRepositoryExt.findById(petTypeId);
+		PetType petType = null;
+		try {
+			petType = petTypeRepositoryExt.findById(petTypeId);
+		} catch (ObjectRetrievalFailureException|EmptyResultDataAccessException e) {
+		// just ignore not found exceptions for Jdbc/Jpa realization
+			return null;
+		}
+		return petType;
 	}
 
 	@Override
@@ -141,7 +185,14 @@ public class ClinicServiceExtImpl implements ClinicServiceExt {
 	@Override
 	@Transactional(readOnly = true)
 	public Specialty findSpecialtyById(int specialtyId) {
-		return specialtyRepositoryExt.findById(specialtyId);
+		Specialty specialty = null;
+		try {
+			specialty = specialtyRepositoryExt.findById(specialtyId);
+		} catch (ObjectRetrievalFailureException|EmptyResultDataAccessException e) {
+		// just ignore not found exceptions for Jdbc/Jpa realization
+			return null;
+		}
+		return specialty;
 	}
 
 	@Override
@@ -171,13 +222,27 @@ public class ClinicServiceExtImpl implements ClinicServiceExt {
 	@Override
 	@Transactional(readOnly = true)
 	public Owner findOwnerById(int id) throws DataAccessException {
-		return ownerRepositoryExt.findById(id);
+		Owner owner = null;
+		try {
+			owner = ownerRepositoryExt.findById(id);
+		} catch (ObjectRetrievalFailureException|EmptyResultDataAccessException e) {
+		// just ignore not found exceptions for Jdbc/Jpa realization
+			return null;
+		}
+		return owner;
 	}
 
 	@Override
 	@Transactional(readOnly = true)
 	public Pet findPetById(int id) throws DataAccessException {
-		return petRepositoryExt.findById(id);
+		Pet pet = null;
+		try {
+			pet = petRepositoryExt.findById(id);
+		} catch (ObjectRetrievalFailureException|EmptyResultDataAccessException e) {
+		// just ignore not found exceptions for Jdbc/Jpa realization
+			return null;
+		}
+		return pet;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceExtImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceExtImpl.java
@@ -1,0 +1,164 @@
+package org.springframework.samples.petclinic.service;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.model.Specialty;
+import org.springframework.samples.petclinic.model.Vet;
+import org.springframework.samples.petclinic.model.Visit;
+import org.springframework.samples.petclinic.repository.OwnerRepositoryExt;
+import org.springframework.samples.petclinic.repository.PetRepositoryExt;
+import org.springframework.samples.petclinic.repository.PetTypeRepositoryExt;
+import org.springframework.samples.petclinic.repository.SpecialtyRepositoryExt;
+import org.springframework.samples.petclinic.repository.VetRepositoryExt;
+import org.springframework.samples.petclinic.repository.VisitRepositoryExt;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ClinicServiceExtImpl extends ClinicServiceImpl implements ClinicServiceExt {
+		
+	private SpecialtyRepositoryExt specialtyRepositoryExt;
+	private PetTypeRepositoryExt petTypeRepositoryExt;
+	private PetRepositoryExt petRepositoryExt;
+	private VetRepositoryExt vetRepositoryExt;
+	private OwnerRepositoryExt ownerRepositoryExt;
+	private VisitRepositoryExt visitRepositoryExt;
+	
+	@Autowired
+	public ClinicServiceExtImpl(
+				@Qualifier("PetRepositoryExt") PetRepositoryExt petRepositoryExt, 
+				@Qualifier("VetRepositoryExt") VetRepositoryExt vetRepositoryExt,
+				@Qualifier("OwnerRepositoryExt") OwnerRepositoryExt ownerRepositoryExt,
+				@Qualifier("VisitRepositoryExt") VisitRepositoryExt visitRepositoryExt,
+				@Qualifier("SpecialtyRepositoryExt") SpecialtyRepositoryExt specialtyRepositoryExt,
+				@Qualifier("PetTypeRepositoryExt") PetTypeRepositoryExt petTypeRepositoryExt) {
+		super(petRepositoryExt, vetRepositoryExt, ownerRepositoryExt, visitRepositoryExt);
+		this.specialtyRepositoryExt = specialtyRepositoryExt; 
+		this.petTypeRepositoryExt = petTypeRepositoryExt;
+		this.petRepositoryExt = petRepositoryExt;
+		this.vetRepositoryExt = vetRepositoryExt;
+		this.ownerRepositoryExt = ownerRepositoryExt;
+		this.visitRepositoryExt = visitRepositoryExt;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Collection<Pet> findAllPets() throws DataAccessException {
+		return petRepositoryExt.findAll();
+	}
+
+	@Override
+	@Transactional
+	public void deletePet(Pet pet) throws DataAccessException {
+		petRepositoryExt.delete(pet);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Visit findVisitById(int visitId) throws DataAccessException {
+		return visitRepositoryExt.findById(visitId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Collection<Visit> findAllVisits() throws DataAccessException {
+		return visitRepositoryExt.findAll();
+	}
+
+	@Override
+	@Transactional
+	public void deleteVisit(Visit visit) throws DataAccessException {
+		visitRepositoryExt.delete(visit);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Vet findVetById(int id) throws DataAccessException {
+		return vetRepositoryExt.findById(id);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Collection<Vet> findAllVets() throws DataAccessException {
+		return vetRepositoryExt.findAll();
+	}
+
+	@Override
+	@Transactional
+	public void saveVet(Vet vet) throws DataAccessException {
+		vetRepositoryExt.save(vet);
+	}
+
+	@Override
+	@Transactional
+	public void deleteVet(Vet vet) throws DataAccessException {
+		vetRepositoryExt.delete(vet);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Collection<Owner> findAllOwners() throws DataAccessException {
+		return ownerRepositoryExt.findAll();
+	}
+
+	@Override
+	@Transactional
+	public void deleteOwner(Owner owner) throws DataAccessException {
+		ownerRepositoryExt.delete(owner);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public PetType findPetTypeById(int petTypeId) {
+		return petTypeRepositoryExt.findById(petTypeId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Collection<PetType> findAllPetTypes() throws DataAccessException {
+		return petTypeRepositoryExt.findAll();
+	}
+
+	@Override
+	@Transactional
+	public void savePetType(PetType petType) throws DataAccessException {
+		petTypeRepositoryExt.save(petType);
+	}
+
+	@Override
+	@Transactional
+	public void deletePetType(PetType petType) throws DataAccessException {
+		petTypeRepositoryExt.delete(petType);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Specialty findSpecialtyById(int specialtyId) {
+		return specialtyRepositoryExt.findById(specialtyId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Collection<Specialty> findAllSpecialties() throws DataAccessException {
+		return specialtyRepositoryExt.findAll();
+	}
+
+	@Override
+	@Transactional
+	public void saveSpecialty(Specialty specialty) throws DataAccessException {
+		specialtyRepositoryExt.save(specialty);
+	}
+
+	@Override
+	@Transactional
+	public void deleteSpecialty(Specialty specialty) throws DataAccessException {
+		specialtyRepositoryExt.delete(specialty);
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -18,6 +18,7 @@ package org.springframework.samples.petclinic.service;
 import java.util.Collection;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Owner;
@@ -47,7 +48,15 @@ public class ClinicServiceImpl implements ClinicService {
     private VisitRepository visitRepository;
 
     @Autowired
-    public ClinicServiceImpl(PetRepository petRepository, VetRepository vetRepository, OwnerRepository ownerRepository, VisitRepository visitRepository) {
+     public ClinicServiceImpl(
+//    		 @Qualifier("PetRepository") PetRepository petRepository,
+//    		 @Qualifier("VetRepository") VetRepository vetRepository,
+//    		 @Qualifier("OwnerRepository") OwnerRepository ownerRepository,
+//    		 @Qualifier("VisitRepository") VisitRepository visitRepository) {
+       		 @Qualifier("PetRepositoryExt") PetRepository petRepository,
+    		 @Qualifier("VetRepositoryExt") VetRepository vetRepository,
+    		 @Qualifier("OwnerRepositoryExt") OwnerRepository ownerRepository,
+    		 @Qualifier("VisitRepositoryExt") VisitRepository visitRepository) {
         this.petRepository = petRepository;
         this.vetRepository = vetRepository;
         this.ownerRepository = ownerRepository;

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -49,14 +49,10 @@ public class ClinicServiceImpl implements ClinicService {
 
     @Autowired
      public ClinicServiceImpl(
-//    		 @Qualifier("PetRepository") PetRepository petRepository,
-//    		 @Qualifier("VetRepository") VetRepository vetRepository,
-//    		 @Qualifier("OwnerRepository") OwnerRepository ownerRepository,
-//    		 @Qualifier("VisitRepository") VisitRepository visitRepository) {
-       		 @Qualifier("PetRepositoryExt") PetRepository petRepository,
-    		 @Qualifier("VetRepositoryExt") VetRepository vetRepository,
-    		 @Qualifier("OwnerRepositoryExt") OwnerRepository ownerRepository,
-    		 @Qualifier("VisitRepositoryExt") VisitRepository visitRepository) {
+       		 @Qualifier("PetRepository") PetRepository petRepository,
+    		 @Qualifier("VetRepository") VetRepository vetRepository,
+    		 @Qualifier("OwnerRepository") OwnerRepository ownerRepository,
+    		 @Qualifier("VisitRepository") VisitRepository visitRepository) {
         this.petRepository = petRepository;
         this.vetRepository = vetRepository;
         this.ownerRepository = ownerRepository;

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -40,6 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Michael Isvy
  */
 @Service
+@Qualifier("ClinicService")
 public class ClinicServiceImpl implements ClinicService {
 
     private PetRepository petRepository;

--- a/src/main/java/org/springframework/samples/petclinic/web/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/OwnerController.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.service.ClinicService;
 import org.springframework.stereotype.Controller;
@@ -47,7 +48,7 @@ public class OwnerController {
 
 
     @Autowired
-    public OwnerController(ClinicService clinicService) {
+    public OwnerController(@Qualifier("ClinicService") ClinicService clinicService) {
         this.clinicService = clinicService;
     }
 

--- a/src/main/java/org/springframework/samples/petclinic/web/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/PetController.java
@@ -16,6 +16,7 @@
 package org.springframework.samples.petclinic.web;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
@@ -44,7 +45,7 @@ public class PetController {
     private final ClinicService clinicService;
 
     @Autowired
-    public PetController(ClinicService clinicService) {
+    public PetController(@Qualifier("ClinicService") ClinicService clinicService) {
         this.clinicService = clinicService;
     }
 

--- a/src/main/java/org/springframework/samples/petclinic/web/PetTypeFormatter.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/PetTypeFormatter.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Locale;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.format.Formatter;
 import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.service.ClinicService;
@@ -43,7 +44,7 @@ public class PetTypeFormatter implements Formatter<PetType> {
 
 
     @Autowired
-    public PetTypeFormatter(ClinicService clinicService) {
+    public PetTypeFormatter(@Qualifier("ClinicService") ClinicService clinicService) {
         this.clinicService = clinicService;
     }
 

--- a/src/main/java/org/springframework/samples/petclinic/web/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/VetController.java
@@ -18,6 +18,7 @@ package org.springframework.samples.petclinic.web;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.samples.petclinic.model.Vets;
 import org.springframework.samples.petclinic.service.ClinicService;
 import org.springframework.stereotype.Controller;
@@ -37,7 +38,7 @@ public class VetController {
 
 
     @Autowired
-    public VetController(ClinicService clinicService) {
+    public VetController(@Qualifier("ClinicService") ClinicService clinicService) {
         this.clinicService = clinicService;
     }
 

--- a/src/main/java/org/springframework/samples/petclinic/web/VisitController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/VisitController.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.Visit;
 import org.springframework.samples.petclinic.service.ClinicService;
@@ -45,7 +46,7 @@ public class VisitController {
 
 
     @Autowired
-    public VisitController(ClinicService clinicService) {
+    public VisitController(@Qualifier("ClinicService") ClinicService clinicService) {
         this.clinicService = clinicService;
     }
 

--- a/src/main/resources/spring/mvc-core-config.xml
+++ b/src/main/resources/spring/mvc-core-config.xml
@@ -19,9 +19,10 @@
     <!--
         - POJOs labeled with the @Controller and @Service annotations are auto-detected.
     -->
-    <context:component-scan
-        base-package="org.springframework.samples.petclinic.web"/>
 
+	<context:component-scan
+        base-package="org.springframework.samples.petclinic.web,org.springframework.samples.petclinic.rest"/>
+	 
     <mvc:annotation-driven conversion-service="conversionService"/>
 
     <!--  all resources inside folder src/main/webapp/resources are mapped so they can be refered to inside JSP files

--- a/src/test/java/org/springframework/samples/petclinic/rest/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/OwnerRestControllerTests.java
@@ -1,0 +1,182 @@
+package org.springframework.samples.petclinic.rest;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.service.ClinicService;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+/**
+ * Test class for {@link OwnerRestController}
+ *
+ * @author Vitaliy Fedoriv
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration({"classpath:spring/mvc-test-config.xml", "classpath:spring/mvc-core-config.xml"})
+@WebAppConfiguration
+public class OwnerRestControllerTests {
+
+    @Autowired
+    private OwnerRestController ownerRestController;
+
+    @Autowired
+    private ClinicService clinicService;
+
+    private MockMvc mockMvc;
+
+    private List<Owner> owners;
+
+    @Before
+    public void initOwners(){
+    	this.mockMvc = MockMvcBuilders.standaloneSetup(ownerRestController).build();
+    	owners = new ArrayList<Owner>();
+
+    	Owner owner = new Owner();
+    	owner.setId(1);
+    	owner.setFirstName("George");
+    	owner.setLastName("Franklin");
+    	owner.setAddress("110 W. Liberty St.");
+    	owner.setCity("Madison");
+    	owner.setTelephone("6085551023");
+    	owners.add(owner);
+    	
+    	owner = new Owner();
+    	owner.setId(2);
+    	owner.setFirstName("Betty");
+    	owner.setLastName("Davis");
+    	owner.setAddress("638 Cardinal Ave.");
+    	owner.setCity("Sun Prairie");
+    	owner.setTelephone("6085551749");
+    	owners.add(owner);
+    	
+    	owner = new Owner();
+    	owner.setId(3);
+    	owner.setFirstName("Eduardo");
+    	owner.setLastName("Rodriquez");
+    	owner.setAddress("2693 Commerce St.");
+    	owner.setCity("McFarland");
+    	owner.setTelephone("6085558763");
+    	owners.add(owner);
+    	
+    	owner = new Owner();
+    	owner.setId(4);
+    	owner.setFirstName("Harold");
+    	owner.setLastName("Davis");
+    	owner.setAddress("563 Friendly St.");
+    	owner.setCity("Windsor");
+    	owner.setTelephone("6085553198");
+    	owners.add(owner);
+    	
+    	
+    }
+    
+    @Test
+    public void testGetOwnerSuccess() throws Exception {
+    	given(this.clinicService.findOwnerById(1)).willReturn(owners.get(0));
+        this.mockMvc.perform(get("/api/owners/1")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.firstName").value("George"));
+    }
+    
+    @Test
+    public void testGetOwnerNotFound() throws Exception {
+    	given(this.clinicService.findOwnerById(-1)).willReturn(null);
+        this.mockMvc.perform(get("/api/owners/-1")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Test
+    public void testGetOwnersListSuccess() throws Exception {
+    	owners.remove(0); 
+    	owners.remove(1);
+    	given(this.clinicService.findOwnerByLastName("Davis")).willReturn(owners);
+        this.mockMvc.perform(get("/api/owners/?lastName=Davis")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.[0].id").value(2))
+            .andExpect(jsonPath("$.[0].firstName").value("Betty"))
+            .andExpect(jsonPath("$.[1].id").value(4))
+            .andExpect(jsonPath("$.[1].firstName").value("Harold"));
+    }
+    
+    @Test
+    public void testGetOwnersListNotFound() throws Exception {
+    	owners.clear();
+    	given(this.clinicService.findOwnerByLastName("0")).willReturn(owners);
+        this.mockMvc.perform(get("/api/owners/?lastName=0")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Ignore
+    @Test
+    public void testCreateOwnerSuccess() throws Exception {
+    	doAnswer(new Answer<Void>() {
+    	     public Void answer(InvocationOnMock invocation) {
+    	         Owner resultOwner = (Owner) invocation.getArguments()[0];
+    	         resultOwner.setId(999);
+    	         System.out.println("resultOwner after call " + resultOwner.toString());
+    	         return null;
+    	     }
+    	}).when(clinicService).saveOwner((Owner) anyObject());
+    	
+    	Owner newOwner = owners.get(0);
+    	newOwner.setId(null);
+    	
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newOwnerAsJSON = mapper.writeValueAsString(newOwner);
+    	System.out.println("newOwnerAsJSON" + newOwnerAsJSON);
+    	newOwner.setId(999);
+    	//newOwner.as;
+    	String resultOwnerAsJSON = mapper.writeValueAsString(newOwner);
+    	System.out.println("resultOwnerAsJSON" + resultOwnerAsJSON);
+// TODO  Uncompleted test
+    	this.mockMvc.perform(post("/api/owners/")
+    		.content(newOwnerAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+    		.andExpect(status().isCreated())
+    		.andExpect(content().json(resultOwnerAsJSON));
+    }
+    
+    @Test
+    public void testCreateOwnerError() throws Exception {
+    	Owner newOwner = owners.get(0);
+    	newOwner.setId(null);
+    	newOwner.setFirstName(null);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newOwnerAsJSON = mapper.writeValueAsString(newOwner);
+    	this.mockMvc.perform(post("/api/owners/")
+        		.content(newOwnerAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        		.andExpect(status().isBadRequest());
+     }
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/OwnerRestControllerTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.rest;
 
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/org/springframework/samples/petclinic/rest/PetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/PetRestControllerTests.java
@@ -1,0 +1,207 @@
+package org.springframework.samples.petclinic.rest;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.service.ClinicServiceExt;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+/**
+ * Test class for {@link PetRestController}
+ *
+ * @author Vitaliy Fedoriv
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration({"classpath:spring/mvc-test-config.xml", "classpath:spring/mvc-core-config.xml"})
+@WebAppConfiguration
+public class PetRestControllerTests {
+
+    @Autowired
+    private PetRestController petRestController;
+
+    @Autowired
+    private ClinicServiceExt clinicService;
+
+    private MockMvc mockMvc;
+
+    private List<Pet> pets;
+
+    @Before
+    public void initPets(){
+    	this.mockMvc = MockMvcBuilders.standaloneSetup(petRestController).build();
+    	pets = new ArrayList<Pet>();
+    	
+    	Owner owner = new Owner();
+    	owner.setId(1);
+    	owner.setFirstName("Eduardo");
+    	owner.setLastName("Rodriquez");
+    	owner.setAddress("2693 Commerce St.");
+    	owner.setCity("McFarland");
+    	owner.setTelephone("6085558763");
+    	
+    	PetType petType = new PetType();
+    	petType.setId(2);
+    	petType.setName("dog");
+
+    	Pet pet = new Pet();
+    	pet.setId(3);
+    	pet.setName("Rosy");
+    	pet.setBirthDate(new Date());
+    	pet.setOwner(owner);
+    	pet.setType(petType);
+    	pets.add(pet);
+    	
+    	pet = new Pet();
+    	pet.setId(4);
+    	pet.setName("Jewel");
+    	pet.setBirthDate(new Date());
+    	pet.setOwner(owner);
+    	pet.setType(petType);
+    	pets.add(pet);
+    }
+    
+    @Test
+    public void testGetPetSuccess() throws Exception {
+    	given(this.clinicService.findPetById(3)).willReturn(pets.get(0));
+        this.mockMvc.perform(get("/api/pets/3")
+        	.accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.id").value(3))
+            .andExpect(jsonPath("$.name").value("Rosy"));
+    }
+    
+    @Test
+    public void testGetPetNotFound() throws Exception {
+    	given(this.clinicService.findPetById(-1)).willReturn(null);
+        this.mockMvc.perform(get("/api/pets/-1")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Test
+    public void testGetAllPetsSuccess() throws Exception {
+    	//pets.remove(0); 
+    	//pets.remove(1);
+    	given(this.clinicService.findAllPets()).willReturn(pets);
+        this.mockMvc.perform(get("/api/pets/")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.[0].id").value(3))
+            .andExpect(jsonPath("$.[0].name").value("Rosy"))
+            .andExpect(jsonPath("$.[1].id").value(4))
+            .andExpect(jsonPath("$.[1].name").value("Jewel"));
+    }
+    
+    @Test
+    public void testGetAllPetsNotFound() throws Exception {
+    	pets.clear();
+    	given(this.clinicService.findAllPets()).willReturn(pets);
+        this.mockMvc.perform(get("/api/pets/")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Test
+    public void testCreatePetSuccess() throws Exception {
+    	Pet newPet = pets.get(0);
+    	newPet.setId(999);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newPetAsJSON = mapper.writeValueAsString(newPet);
+    	this.mockMvc.perform(post("/api/pets/")
+    		.content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+    		.andExpect(status().isCreated());
+    }
+    
+    @Test
+    public void testCreatePetError() throws Exception {
+    	Pet newPet = pets.get(0);
+    	newPet.setId(null);
+    	newPet.setName(null);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newPetAsJSON = mapper.writeValueAsString(newPet);
+    	this.mockMvc.perform(post("/api/pets/")
+        		.content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        		.andExpect(status().isBadRequest());
+     }
+    
+    @Test
+    public void testUpdatePetSuccess() throws Exception {
+    	Pet newPet = pets.get(0);
+    	newPet.setName("Rosy I");
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newPetAsJSON = mapper.writeValueAsString(newPet);
+    	this.mockMvc.perform(put("/api/pets/3")
+    		.content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(content().contentType("application/json;charset=UTF-8"))
+        	.andExpect(status().isNoContent());
+    	
+    	this.mockMvc.perform(get("/api/pets/3")
+           	.accept(MediaType.APPLICATION_JSON).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.id").value(3))
+            .andExpect(jsonPath("$.name").value("Rosy I"));
+        	
+    }
+    
+    @Test
+    public void testUpdatePetError() throws Exception {
+    	Pet newPet = pets.get(0);
+    	newPet.setName("");
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newPetAsJSON = mapper.writeValueAsString(newPet);
+    	this.mockMvc.perform(put("/api/pets/3")
+    		.content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isBadRequest());
+     }
+    
+    @Test
+    public void testDeletePetSuccess() throws Exception {
+    	Pet newPet = pets.get(0);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newPetAsJSON = mapper.writeValueAsString(newPet);
+    	given(this.clinicService.findPetById(3)).willReturn(pets.get(0));
+    	this.mockMvc.perform(delete("/api/pets/3")
+    		.content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isNoContent());
+    }
+    
+    @Test
+    public void testDeletePetError() throws Exception {
+    	Pet newPet = pets.get(0);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newPetAsJSON = mapper.writeValueAsString(newPet);
+    	given(this.clinicService.findPetById(-1)).willReturn(null);
+    	this.mockMvc.perform(delete("/api/pets/-1")
+    		.content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isNotFound());
+    }
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/PetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/PetRestControllerTests.java
@@ -106,8 +106,6 @@ public class PetRestControllerTests {
     
     @Test
     public void testGetAllPetsSuccess() throws Exception {
-    	//pets.remove(0); 
-    	//pets.remove(1);
     	given(this.clinicService.findAllPets()).willReturn(pets);
         this.mockMvc.perform(get("/api/pets/")
         	.accept(MediaType.APPLICATION_JSON))
@@ -153,6 +151,7 @@ public class PetRestControllerTests {
     
     @Test
     public void testUpdatePetSuccess() throws Exception {
+    	given(this.clinicService.findPetById(3)).willReturn(pets.get(0));
     	Pet newPet = pets.get(0);
     	newPet.setName("Rosy I");
     	ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/org/springframework/samples/petclinic/rest/PetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/PetRestControllerTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.rest;
 
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/org/springframework/samples/petclinic/rest/PetTypeRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/PetTypeRestControllerTests.java
@@ -1,5 +1,196 @@
 package org.springframework.samples.petclinic.rest;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.service.ClinicServiceExt;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+/**
+ * Test class for {@link PetTypeRestController}
+ *
+ * @author Vitaliy Fedoriv
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration({"classpath:spring/mvc-test-config.xml", "classpath:spring/mvc-core-config.xml"})
+@WebAppConfiguration
 public class PetTypeRestControllerTests {
+
+    @Autowired
+    private PetTypeRestController petTypeRestController;
+
+    @Autowired
+    private ClinicServiceExt clinicService;
+
+    private MockMvc mockMvc;
+
+    private List<PetType> petTypes;
+
+    @Before
+    public void initPetTypes(){
+    	this.mockMvc = MockMvcBuilders.standaloneSetup(petTypeRestController).build();
+    	petTypes = new ArrayList<PetType>();
+
+    	PetType petType = new PetType();
+    	petType.setId(1);
+    	petType.setName("cat");
+    	petTypes.add(petType);
+    	
+    	petType = new PetType();
+    	petType.setId(2);
+    	petType.setName("dog");
+    	petTypes.add(petType);
+    	
+    	petType = new PetType();
+    	petType.setId(3);
+    	petType.setName("lizard");
+    	petTypes.add(petType);
+    	
+    	petType = new PetType();
+    	petType.setId(4);
+    	petType.setName("snake");
+    	petTypes.add(petType);
+    }
+    
+    @Test
+    public void testGetPetTypeSuccess() throws Exception {
+    	given(this.clinicService.findPetTypeById(1)).willReturn(petTypes.get(0));
+        this.mockMvc.perform(get("/api/pettypes/1")
+        	.accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.name").value("cat"));
+    }
+    
+    @Test
+    public void testGetPetTypeNotFound() throws Exception {
+    	given(this.clinicService.findPetTypeById(-1)).willReturn(null);
+        this.mockMvc.perform(get("/api/pettypes/-1")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Test
+    public void testGetAllPetTypesSuccess() throws Exception {
+    	petTypes.remove(0); 
+    	petTypes.remove(1);
+    	given(this.clinicService.findAllPetTypes()).willReturn(petTypes);
+        this.mockMvc.perform(get("/api/pettypes/")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+        	.andExpect(jsonPath("$.[0].id").value(2))
+        	.andExpect(jsonPath("$.[0].name").value("dog"))
+        	.andExpect(jsonPath("$.[1].id").value(4))
+        	.andExpect(jsonPath("$.[1].name").value("snake"));
+    }
+    
+    @Test
+    public void testGetAllPetTypesNotFound() throws Exception {
+    	petTypes.clear();
+    	given(this.clinicService.findAllPetTypes()).willReturn(petTypes);
+        this.mockMvc.perform(get("/api/pettypes/")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Test
+    public void testCreatePetTypeSuccess() throws Exception {
+    	PetType newPetType = petTypes.get(0);
+    	newPetType.setId(999);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newPetTypeAsJSON = mapper.writeValueAsString(newPetType);
+    	this.mockMvc.perform(post("/api/pettypes/")
+    		.content(newPetTypeAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+    		.andExpect(status().isCreated());
+    }
+    
+    @Test
+    public void testCreatePetTypeError() throws Exception {
+    	PetType newPetType = petTypes.get(0);
+    	newPetType.setId(null);
+    	newPetType.setName(null);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newPetTypeAsJSON = mapper.writeValueAsString(newPetType);
+    	this.mockMvc.perform(post("/api/pettypes/")
+        		.content(newPetTypeAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        		.andExpect(status().isBadRequest());
+     }
+    
+    @Test
+    public void testUpdatePetTypeSuccess() throws Exception {
+    	given(this.clinicService.findPetTypeById(2)).willReturn(petTypes.get(1));
+    	PetType newPetType = petTypes.get(1);
+    	newPetType.setName("dog I");
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newPetTypeAsJSON = mapper.writeValueAsString(newPetType);
+    	this.mockMvc.perform(put("/api/pettypes/2")
+    		.content(newPetTypeAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(content().contentType("application/json;charset=UTF-8"))
+        	.andExpect(status().isNoContent());
+    	
+    	this.mockMvc.perform(get("/api/pettypes/2")
+           	.accept(MediaType.APPLICATION_JSON).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.id").value(2))
+            .andExpect(jsonPath("$.name").value("dog I"));	
+    }
+    
+    @Test
+    public void testUpdatePetTypeError() throws Exception {
+    	PetType newPetType = petTypes.get(0);
+    	newPetType.setName("");
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newPetTypeAsJSON = mapper.writeValueAsString(newPetType);
+    	this.mockMvc.perform(put("/api/pettypes/1")
+    		.content(newPetTypeAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isBadRequest());
+     }
+    
+    @Test
+    public void testDeletePetTypeSuccess() throws Exception {
+    	PetType newPetType = petTypes.get(0);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newPetTypeAsJSON = mapper.writeValueAsString(newPetType);
+    	given(this.clinicService.findPetTypeById(1)).willReturn(petTypes.get(0));
+    	this.mockMvc.perform(delete("/api/pettypes/1")
+    		.content(newPetTypeAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isNoContent());
+    }
+    
+    @Test
+    public void testDeletePetTypeError() throws Exception {
+    	PetType newPetType = petTypes.get(0);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newPetTypeAsJSON = mapper.writeValueAsString(newPetType);
+    	given(this.clinicService.findPetTypeById(-1)).willReturn(null);
+    	this.mockMvc.perform(delete("/api/pettypes/-1")
+    		.content(newPetTypeAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isNotFound());
+    }
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/rest/PetTypeRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/PetTypeRestControllerTests.java
@@ -1,0 +1,5 @@
+package org.springframework.samples.petclinic.rest;
+
+public class PetTypeRestControllerTests {
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/PetTypeRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/PetTypeRestControllerTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.rest;
 
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/org/springframework/samples/petclinic/rest/SpecialtyRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/SpecialtyRestControllerTests.java
@@ -1,0 +1,5 @@
+package org.springframework.samples.petclinic.rest;
+
+public class SpecialtyRestControllerTests {
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/SpecialtyRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/SpecialtyRestControllerTests.java
@@ -1,5 +1,205 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.rest;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.model.Specialty;
+import org.springframework.samples.petclinic.service.ClinicServiceExt;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Test class for {@link SpecialtyRestController}
+ *
+ * @author Vitaliy Fedoriv
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration({"classpath:spring/mvc-test-config.xml", "classpath:spring/mvc-core-config.xml"})
+@WebAppConfiguration
 public class SpecialtyRestControllerTests {
 
+    @Autowired
+    private SpecialtyRestController specialtyRestController;
+
+    @Autowired
+    private ClinicServiceExt clinicService;
+
+    private MockMvc mockMvc;
+
+    private List<Specialty> specialties;
+
+    @Before
+    public void initSpecialtys(){
+    	this.mockMvc = MockMvcBuilders.standaloneSetup(specialtyRestController).build();
+    	specialties = new ArrayList<Specialty>();
+
+    	Specialty specialty = new Specialty();
+    	specialty.setId(1);
+    	specialty.setName("radiology");
+    	specialties.add(specialty);
+    	
+    	specialty = new Specialty();
+    	specialty.setId(2);
+    	specialty.setName("surgery");
+    	specialties.add(specialty);
+    	
+    	specialty = new Specialty();
+    	specialty.setId(3);
+    	specialty.setName("dentistry");
+    	specialties.add(specialty);
+
+    }
+    
+    @Test
+    public void testGetSpecialtySuccess() throws Exception {
+    	given(this.clinicService.findSpecialtyById(1)).willReturn(specialties.get(0));
+        this.mockMvc.perform(get("/api/specialties/1")
+        	.accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.name").value("radiology"));
+    }
+    
+    @Test
+    public void testGetSpecialtyNotFound() throws Exception {
+    	given(this.clinicService.findSpecialtyById(-1)).willReturn(null);
+        this.mockMvc.perform(get("/api/specialties/-1")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Test
+    public void testGetAllSpecialtysSuccess() throws Exception {
+    	specialties.remove(0); 
+    	given(this.clinicService.findAllSpecialties()).willReturn(specialties);
+        this.mockMvc.perform(get("/api/specialties/")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+        	.andExpect(jsonPath("$.[0].id").value(2))
+        	.andExpect(jsonPath("$.[0].name").value("surgery"))
+        	.andExpect(jsonPath("$.[1].id").value(3))
+        	.andExpect(jsonPath("$.[1].name").value("dentistry"));
+    }
+    
+    @Test
+    public void testGetAllSpecialtysNotFound() throws Exception {
+    	specialties.clear();
+    	given(this.clinicService.findAllSpecialties()).willReturn(specialties);
+        this.mockMvc.perform(get("/api/specialties/")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Test
+    public void testCreateSpecialtySuccess() throws Exception {
+    	Specialty newSpecialty = specialties.get(0);
+    	newSpecialty.setId(999);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newSpecialtyAsJSON = mapper.writeValueAsString(newSpecialty);
+    	this.mockMvc.perform(post("/api/specialties/")
+    		.content(newSpecialtyAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+    		.andExpect(status().isCreated());
+    }
+    
+    @Test
+    public void testCreateSpecialtyError() throws Exception {
+    	Specialty newSpecialty = specialties.get(0);
+    	newSpecialty.setId(null);
+    	newSpecialty.setName(null);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newSpecialtyAsJSON = mapper.writeValueAsString(newSpecialty);
+    	this.mockMvc.perform(post("/api/specialties/")
+        		.content(newSpecialtyAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        		.andExpect(status().isBadRequest());
+     }
+    
+    @Test
+    public void testUpdateSpecialtySuccess() throws Exception {
+    	given(this.clinicService.findSpecialtyById(2)).willReturn(specialties.get(1));
+    	Specialty newSpecialty = specialties.get(1);
+    	newSpecialty.setName("surgery I");
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newSpecialtyAsJSON = mapper.writeValueAsString(newSpecialty);
+    	this.mockMvc.perform(put("/api/specialties/2")
+    		.content(newSpecialtyAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(content().contentType("application/json;charset=UTF-8"))
+        	.andExpect(status().isNoContent());
+    	
+    	this.mockMvc.perform(get("/api/specialties/2")
+           	.accept(MediaType.APPLICATION_JSON).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.id").value(2))
+            .andExpect(jsonPath("$.name").value("surgery I"));	
+    }
+    
+    @Test
+    public void testUpdateSpecialtyError() throws Exception {
+    	Specialty newSpecialty = specialties.get(0);
+    	newSpecialty.setName("");
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newSpecialtyAsJSON = mapper.writeValueAsString(newSpecialty);
+    	this.mockMvc.perform(put("/api/specialties/1")
+    		.content(newSpecialtyAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isBadRequest());
+     }
+    
+    @Test
+    public void testDeleteSpecialtySuccess() throws Exception {
+    	Specialty newSpecialty = specialties.get(0);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newSpecialtyAsJSON = mapper.writeValueAsString(newSpecialty);
+    	given(this.clinicService.findSpecialtyById(1)).willReturn(specialties.get(0));
+    	this.mockMvc.perform(delete("/api/specialties/1")
+    		.content(newSpecialtyAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isNoContent());
+    }
+    
+    @Test
+    public void testDeleteSpecialtyError() throws Exception {
+    	Specialty newSpecialty = specialties.get(0);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newSpecialtyAsJSON = mapper.writeValueAsString(newSpecialty);
+    	given(this.clinicService.findSpecialtyById(-1)).willReturn(null);
+    	this.mockMvc.perform(delete("/api/specialties/-1")
+    		.content(newSpecialtyAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isNotFound());
+    }
 }

--- a/src/test/java/org/springframework/samples/petclinic/rest/VetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/VetRestControllerTests.java
@@ -1,5 +1,196 @@
 package org.springframework.samples.petclinic.rest;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.model.Vet;
+import org.springframework.samples.petclinic.service.ClinicServiceExt;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+/**
+ * Test class for {@link VetRestController}
+ *
+ * @author Vitaliy Fedoriv
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration({"classpath:spring/mvc-test-config.xml", "classpath:spring/mvc-core-config.xml"})
+@WebAppConfiguration
 public class VetRestControllerTests {
 
+    @Autowired
+    private VetRestController vetRestController;
+
+    @Autowired
+    private ClinicServiceExt clinicService;
+
+    private MockMvc mockMvc;
+
+    private List<Vet> vets;
+
+    @Before
+    public void initVets(){
+    	this.mockMvc = MockMvcBuilders.standaloneSetup(vetRestController).build();
+    	vets = new ArrayList<Vet>();
+    	
+    	
+    	Vet vet = new Vet();
+    	vet.setId(1);
+    	vet.setFirstName("James");
+    	vet.setLastName("Carter");
+    	vets.add(vet);
+
+    	vet = new Vet();
+    	vet.setId(2);
+    	vet.setFirstName("Helen");
+    	vet.setLastName("Leary");
+    	vets.add(vet);
+    	
+    	vet = new Vet();
+    	vet.setId(3);
+    	vet.setFirstName("Linda");
+    	vet.setLastName("Douglas");
+    	vets.add(vet);
+    }
+    
+    @Test
+    public void testGetVetSuccess() throws Exception {
+    	given(this.clinicService.findVetById(1)).willReturn(vets.get(0));
+        this.mockMvc.perform(get("/api/vets/1")
+        	.accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.firstName").value("James"));
+    }
+    
+    @Test
+    public void testGetVetNotFound() throws Exception {
+    	given(this.clinicService.findVetById(-1)).willReturn(null);
+        this.mockMvc.perform(get("/api/vets/-1")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Test
+    public void testGetAllVetsSuccess() throws Exception {
+    	//vets.remove(2); 
+    	//vets.remove(1);
+    	given(this.clinicService.findAllVets()).willReturn(vets);
+        this.mockMvc.perform(get("/api/vets/")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.[0].id").value(1))
+            .andExpect(jsonPath("$.[0].firstName").value("James"))
+            .andExpect(jsonPath("$.[1].id").value(2))
+            .andExpect(jsonPath("$.[1].firstName").value("Helen"));
+    }
+    
+    @Test
+    public void testGetAllVetsNotFound() throws Exception {
+    	vets.clear();
+    	given(this.clinicService.findAllVets()).willReturn(vets);
+        this.mockMvc.perform(get("/api/vets/")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Test
+    public void testCreateVetSuccess() throws Exception {
+    	Vet newVet = vets.get(0);
+    	newVet.setId(999);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newVetAsJSON = mapper.writeValueAsString(newVet);
+    	this.mockMvc.perform(post("/api/vets/")
+    		.content(newVetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+    		.andExpect(status().isCreated());
+    }
+    
+    @Test
+    public void testCreateVetError() throws Exception {
+    	Vet newVet = vets.get(0);
+    	newVet.setId(null);
+    	newVet.setFirstName(null);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newVetAsJSON = mapper.writeValueAsString(newVet);
+    	this.mockMvc.perform(post("/api/vets/")
+        		.content(newVetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        		.andExpect(status().isBadRequest());
+     }
+    
+    @Test
+    public void testUpdateVetSuccess() throws Exception {
+    	Vet newVet = vets.get(0);
+    	newVet.setFirstName("James");
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newVetAsJSON = mapper.writeValueAsString(newVet);
+    	this.mockMvc.perform(put("/api/vets/1")
+    		.content(newVetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(content().contentType("application/json;charset=UTF-8"))
+        	.andExpect(status().isNoContent());
+    	
+    	this.mockMvc.perform(get("/api/vets/1")
+           	.accept(MediaType.APPLICATION_JSON).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.firstName").value("James"));
+        	
+    }
+    
+    @Test
+    public void testUpdateVetError() throws Exception {
+    	Vet newVet = vets.get(0);
+    	newVet.setFirstName("");
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newVetAsJSON = mapper.writeValueAsString(newVet);
+    	this.mockMvc.perform(put("/api/vets/1")
+    		.content(newVetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isBadRequest());
+     }
+    
+    @Test
+    public void testDeleteVetSuccess() throws Exception {
+    	Vet newVet = vets.get(0);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newVetAsJSON = mapper.writeValueAsString(newVet);
+    	given(this.clinicService.findVetById(1)).willReturn(vets.get(0));
+    	this.mockMvc.perform(delete("/api/vets/1")
+    		.content(newVetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isNoContent());
+    }
+    
+    @Test
+    public void testDeleteVetError() throws Exception {
+    	Vet newVet = vets.get(0);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newVetAsJSON = mapper.writeValueAsString(newVet);
+    	given(this.clinicService.findVetById(-1)).willReturn(null);
+    	this.mockMvc.perform(delete("/api/vets/-1")
+    		.content(newVetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isNotFound());
+    }
+
 }
+

--- a/src/test/java/org/springframework/samples/petclinic/rest/VetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/VetRestControllerTests.java
@@ -1,0 +1,5 @@
+package org.springframework.samples.petclinic.rest;
+
+public class VetRestControllerTests {
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/VetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/VetRestControllerTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.rest;
 
 import static org.mockito.BDDMockito.given;
@@ -27,12 +43,12 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-
 /**
  * Test class for {@link VetRestController}
  *
  * @author Vitaliy Fedoriv
  */
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({"classpath:spring/mvc-test-config.xml", "classpath:spring/mvc-core-config.xml"})
 @WebAppConfiguration
@@ -94,8 +110,6 @@ public class VetRestControllerTests {
     
     @Test
     public void testGetAllVetsSuccess() throws Exception {
-    	//vets.remove(2); 
-    	//vets.remove(1);
     	given(this.clinicService.findAllVets()).willReturn(vets);
         this.mockMvc.perform(get("/api/vets/")
         	.accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/org/springframework/samples/petclinic/rest/VisitRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/VisitRestControllerTests.java
@@ -1,5 +1,214 @@
 package org.springframework.samples.petclinic.rest;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.model.Visit;
+import org.springframework.samples.petclinic.service.ClinicServiceExt;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+/**
+ * Test class for {@link VisitRestController}
+ *
+ * @author Vitaliy Fedoriv
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration({"classpath:spring/mvc-test-config.xml", "classpath:spring/mvc-core-config.xml"})
+@WebAppConfiguration
 public class VisitRestControllerTests {
+
+    @Autowired
+    private VisitRestController visitRestController;
+
+    @Autowired
+    private ClinicServiceExt clinicService;
+
+    private MockMvc mockMvc;
+
+    private List<Visit> visits;
+
+    @Before
+    public void initVisits(){
+    	this.mockMvc = MockMvcBuilders.standaloneSetup(visitRestController).build();
+    	visits = new ArrayList<Visit>();
+    	
+    	Owner owner = new Owner();
+    	owner.setId(1);
+    	owner.setFirstName("Eduardo");
+    	owner.setLastName("Rodriquez");
+    	owner.setAddress("2693 Commerce St.");
+    	owner.setCity("McFarland");
+    	owner.setTelephone("6085558763");
+    	
+    	PetType petType = new PetType();
+    	petType.setId(2);
+    	petType.setName("dog");
+    	
+    	Pet pet = new Pet();
+    	pet.setId(8);
+    	pet.setName("Rosy");
+    	pet.setBirthDate(new Date());
+    	pet.setOwner(owner);
+    	pet.setType(petType);
+    	
+
+    	Visit visit = new Visit();
+    	visit.setId(2);
+    	visit.setPet(pet);
+    	visit.setDate(new Date());
+    	visit.setDescription("rabies shot");
+    	visits.add(visit);
+    	
+    	visit = new Visit();
+    	visit.setId(3);
+    	visit.setPet(pet);
+    	visit.setDate(new Date());
+    	visit.setDescription("neutered");
+    	visits.add(visit);
+    	
+
+    }
+    
+    @Test
+    public void testGetVisitSuccess() throws Exception {
+    	given(this.clinicService.findVisitById(2)).willReturn(visits.get(0));
+        this.mockMvc.perform(get("/api/visits/2")
+        	.accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.id").value(2))
+            .andExpect(jsonPath("$.description").value("rabies shot"));
+    }
+    
+    @Test
+    public void testGetVisitNotFound() throws Exception {
+    	given(this.clinicService.findVisitById(-1)).willReturn(null);
+        this.mockMvc.perform(get("/api/visits/-1")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Test
+    public void testGetAllVisitsSuccess() throws Exception {
+    	given(this.clinicService.findAllVisits()).willReturn(visits);
+        this.mockMvc.perform(get("/api/visits/")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+        	.andExpect(jsonPath("$.[0].id").value(2))
+        	.andExpect(jsonPath("$.[0].description").value("rabies shot"))
+        	.andExpect(jsonPath("$.[1].id").value(3))
+        	.andExpect(jsonPath("$.[1].description").value("neutered"));
+    }
+    
+    @Test
+    public void testGetAllVisitsNotFound() throws Exception {
+    	visits.clear();
+    	given(this.clinicService.findAllVisits()).willReturn(visits);
+        this.mockMvc.perform(get("/api/visits/")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Test
+    public void testCreateVisitSuccess() throws Exception {
+    	Visit newVisit = visits.get(0);
+    	newVisit.setId(999);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newVisitAsJSON = mapper.writeValueAsString(newVisit);
+    	this.mockMvc.perform(post("/api/visits/")
+    		.content(newVisitAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+    		.andExpect(status().isCreated());
+    }
+    
+    @Test
+    public void testCreateVisitError() throws Exception {
+    	Visit newVisit = visits.get(0);
+    	newVisit.setId(null);
+    	newVisit.setPet(null);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newVisitAsJSON = mapper.writeValueAsString(newVisit);
+    	this.mockMvc.perform(post("/api/visits/")
+        		.content(newVisitAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        		.andExpect(status().isBadRequest());
+     }
+    
+    @Test
+    public void testUpdateVisitSuccess() throws Exception {
+    	given(this.clinicService.findVisitById(2)).willReturn(visits.get(0));
+    	Visit newVisit = visits.get(0);
+    	newVisit.setDescription("rabies shot test");
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newVisitAsJSON = mapper.writeValueAsString(newVisit);
+    	this.mockMvc.perform(put("/api/visits/2")
+    		.content(newVisitAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(content().contentType("application/json;charset=UTF-8"))
+        	.andExpect(status().isNoContent());
+    	
+    	this.mockMvc.perform(get("/api/visits/2")
+           	.accept(MediaType.APPLICATION_JSON).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.id").value(2))
+            .andExpect(jsonPath("$.description").value("rabies shot test"));	
+    }
+    
+    @Test
+    public void testUpdateVisitError() throws Exception {
+    	Visit newVisit = visits.get(0);
+    	newVisit.setPet(null);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newVisitAsJSON = mapper.writeValueAsString(newVisit);
+    	this.mockMvc.perform(put("/api/visits/2")
+    		.content(newVisitAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isBadRequest());
+     }
+    
+    @Test
+    public void testDeleteVisitSuccess() throws Exception {
+    	Visit newVisit = visits.get(0);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newVisitAsJSON = mapper.writeValueAsString(newVisit);
+    	given(this.clinicService.findVisitById(2)).willReturn(visits.get(0));
+    	this.mockMvc.perform(delete("/api/visits/2")
+    		.content(newVisitAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isNoContent());
+    }
+    
+    @Test
+    public void testDeleteVisitError() throws Exception {
+    	Visit newVisit = visits.get(0);
+    	ObjectMapper mapper = new ObjectMapper();
+    	String newVisitAsJSON = mapper.writeValueAsString(newVisit);
+    	given(this.clinicService.findVisitById(-1)).willReturn(null);
+    	this.mockMvc.perform(delete("/api/visits/-1")
+    		.content(newVisitAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+        	.andExpect(status().isNotFound());
+    }
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/rest/VisitRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/VisitRestControllerTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.samples.petclinic.rest;
 
 import static org.mockito.BDDMockito.given;
@@ -31,12 +47,12 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-
 /**
  * Test class for {@link VisitRestController}
  *
  * @author Vitaliy Fedoriv
  */
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({"classpath:spring/mvc-test-config.xml", "classpath:spring/mvc-core-config.xml"})
 @WebAppConfiguration

--- a/src/test/java/org/springframework/samples/petclinic/rest/VisitRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/VisitRestControllerTests.java
@@ -1,0 +1,5 @@
+package org.springframework.samples.petclinic.rest;
+
+public class VisitRestControllerTests {
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/service/AbstractClinicServiceExtTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/AbstractClinicServiceExtTests.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.Date;
+
+import javax.transaction.Transactional;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.model.Specialty;
+import org.springframework.samples.petclinic.model.Vet;
+import org.springframework.samples.petclinic.model.Visit;
+import org.springframework.samples.petclinic.util.EntityUtils;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * <p> Base class for {@link ClinicServiceExt} integration tests. </p> <p> Subclasses should specify Spring context
+ * configuration using {@link ContextConfiguration @ContextConfiguration} annotation </p> <p>
+ * AbstractclinicServiceExtTests and its subclasses benefit from the following services provided by the Spring
+ * TestContext Framework: </p> <ul> <li><strong>Spring IoC container caching</strong> which spares us unnecessary set up
+ * time between test execution.</li> <li><strong>Dependency Injection</strong> of test fixture instances, meaning that
+ * we don't need to perform application context lookups. See the use of {@link Autowired @Autowired} on the <code>{@link
+ * AbstractClinicServiceExtTests#clinicServiceExt clinicServiceExt}</code> instance variable, which uses autowiring <em>by
+ * type</em>. <li><strong>Transaction management</strong>, meaning each test method is executed in its own transaction,
+ * which is automatically rolled back by default. Thus, even if tests insert or otherwise change database state, there
+ * is no need for a teardown or cleanup script. <li> An {@link org.springframework.context.ApplicationContext
+ * ApplicationContext} is also inherited and can be used for explicit bean lookup if necessary. </li> </ul>
+ * 
+ * @author Vitaliy Fedoriv
+ *
+ */
+
+public abstract class AbstractClinicServiceExtTests {
+	
+    @Autowired
+    @Qualifier("ClinicServiceExt")
+    protected ClinicServiceExt clinicService;
+    
+    @Test
+    public void shouldFindAllPets(){
+        Collection<Pet> pets = this.clinicService.findAllPets();
+        Pet pet1 = EntityUtils.getById(pets, Pet.class, 1);
+        assertThat(pet1.getName()).isEqualTo("Leo");
+        Pet pet3 = EntityUtils.getById(pets, Pet.class, 3);
+        assertThat(pet3.getName()).isEqualTo("Rosy");
+    }
+    
+    @Test
+    @Transactional
+    public void shouldDeletePet(){
+        Pet pet = this.clinicService.findPetById(1);
+        this.clinicService.deletePet(pet);
+        try {
+        pet = this.clinicService.findPetById(1);
+		} catch (Exception e) {
+			pet = null;
+		}
+        assertThat(pet).isNull();
+    }
+    
+    @Test
+    public void shouldFindVisitDyId(){
+    	Visit visit = this.clinicService.findVisitById(1);
+    	assertThat(visit.getId()).isEqualTo(1);
+    	assertThat(visit.getPet().getName()).isEqualTo("Samantha");
+    }
+    
+    @Test
+    public void shouldFindAllVisits(){
+        Collection<Visit> visits = this.clinicService.findAllVisits();
+        Visit visit1 = EntityUtils.getById(visits, Visit.class, 1);
+        assertThat(visit1.getPet().getName()).isEqualTo("Samantha");
+        Visit visit3 = EntityUtils.getById(visits, Visit.class, 3);
+        assertThat(visit3.getPet().getName()).isEqualTo("Max");
+    }
+    
+    @Test
+    @Transactional
+    public void shouldInsertVisit() {
+        Collection<Visit> visits = this.clinicService.findAllVisits();
+        int found = visits.size();
+        
+        Pet pet = this.clinicService.findPetById(1);
+
+        Visit visit = new Visit();
+        visit.setPet(pet);
+        visit.setDate(new Date());
+        visit.setDescription("new visit");
+        
+                
+        this.clinicService.saveVisit(visit);
+        assertThat(visit.getId().longValue()).isNotEqualTo(0);
+
+        visits = this.clinicService.findAllVisits();
+        assertThat(visits.size()).isEqualTo(found + 1);
+    }
+    
+    @Test
+    @Transactional
+    public void shouldUpdateVisit(){
+    	Visit visit = this.clinicService.findVisitById(1);
+    	String oldDesc = visit.getDescription();
+        String newDesc = oldDesc + "X";
+        visit.setDescription(newDesc);
+        this.clinicService.saveVisit(visit);
+        visit = this.clinicService.findVisitById(1);
+        assertThat(visit.getDescription()).isEqualTo(newDesc);
+    }
+    
+    @Test
+    @Transactional
+    public void shouldDeleteVisit(){
+    	Visit visit = this.clinicService.findVisitById(1);
+        this.clinicService.deleteVisit(visit);
+        try {
+        	visit = this.clinicService.findVisitById(1);
+		} catch (Exception e) {
+			visit = null;
+		}
+        assertThat(visit).isNull();
+    }
+    
+    @Test
+    public void shouldFindVetDyId(){
+    	Vet vet = this.clinicService.findVetById(1);
+    	assertThat(vet.getFirstName()).isEqualTo("James");
+    	assertThat(vet.getLastName()).isEqualTo("Carter");
+    }
+    
+    @Test
+    @Transactional
+    public void shouldInsertVet() {
+        Collection<Vet> vets = this.clinicService.findAllVets();
+        int found = vets.size();
+
+        Vet vet = new Vet();
+        vet.setFirstName("John");
+        vet.setLastName("Dow");
+                
+        this.clinicService.saveVet(vet);
+        assertThat(vet.getId().longValue()).isNotEqualTo(0);
+
+        vets = this.clinicService.findAllVets();
+        assertThat(vets.size()).isEqualTo(found + 1);
+    }
+    
+    @Test
+    @Transactional
+    public void shouldUpdateVet(){
+    	Vet vet = this.clinicService.findVetById(1);
+    	String oldLastName = vet.getLastName();
+        String newLastName = oldLastName + "X";
+        vet.setLastName(newLastName);
+        this.clinicService.saveVet(vet);
+        vet = this.clinicService.findVetById(1);
+        assertThat(vet.getLastName()).isEqualTo(newLastName);
+    }
+    
+    @Test
+    @Transactional
+    public void shouldDeleteVet(){
+    	Vet vet = this.clinicService.findVetById(1);
+        this.clinicService.deleteVet(vet);
+        try {
+        	vet = this.clinicService.findVetById(1);
+		} catch (Exception e) {
+			vet = null;
+		}
+        assertThat(vet).isNull();
+    }
+    
+    @Test
+    public void shouldFindAllOwners(){
+        Collection<Owner> owners = this.clinicService.findAllOwners();
+        Owner owner1 = EntityUtils.getById(owners, Owner.class, 1);
+        assertThat(owner1.getFirstName()).isEqualTo("George");
+        Owner owner3 = EntityUtils.getById(owners, Owner.class, 3);
+        assertThat(owner3.getFirstName()).isEqualTo("Eduardo");
+    }
+    
+    @Test
+    @Transactional
+    public void shouldDeleteOwner(){
+    	Owner owner = this.clinicService.findOwnerById(1);
+        this.clinicService.deleteOwner(owner);
+        try {
+        	owner = this.clinicService.findOwnerById(1);
+		} catch (Exception e) {
+			owner = null;
+		}
+        assertThat(owner).isNull();
+    }
+    
+    @Test
+    public void shouldFindPetTypeById(){
+    	PetType petType = this.clinicService.findPetTypeById(1);
+    	assertThat(petType.getName()).isEqualTo("cat");
+    }
+    
+    @Test
+    public void shouldFindAllPetTypes(){
+        Collection<PetType> petTypes = this.clinicService.findAllPetTypes();
+        PetType petType1 = EntityUtils.getById(petTypes, PetType.class, 1);
+        assertThat(petType1.getName()).isEqualTo("cat");
+        PetType petType3 = EntityUtils.getById(petTypes, PetType.class, 3);
+        assertThat(petType3.getName()).isEqualTo("lizard");
+    }
+    
+    @Test
+    @Transactional
+    public void shouldInsertPetType() {
+        Collection<PetType> petTypes = this.clinicService.findAllPetTypes();
+        int found = petTypes.size();
+
+        PetType petType = new PetType();
+        petType.setName("tiger");
+        
+        this.clinicService.savePetType(petType);
+        assertThat(petType.getId().longValue()).isNotEqualTo(0);
+
+        petTypes = this.clinicService.findAllPetTypes();
+        assertThat(petTypes.size()).isEqualTo(found + 1);
+    }
+    
+    @Test
+    @Transactional
+    public void shouldUpdatePetType(){
+    	PetType petType = this.clinicService.findPetTypeById(1);
+    	String oldLastName = petType.getName();
+        String newLastName = oldLastName + "X";
+        petType.setName(newLastName);
+        this.clinicService.savePetType(petType);
+        petType = this.clinicService.findPetTypeById(1);
+        assertThat(petType.getName()).isEqualTo(newLastName);
+    }
+    
+    @Test
+    @Transactional
+    public void shouldDeletePetType(){
+    	PetType petType = this.clinicService.findPetTypeById(1);
+        this.clinicService.deletePetType(petType);
+        try {
+        	petType = this.clinicService.findPetTypeById(1);
+		} catch (Exception e) {
+			petType = null;
+		}
+        assertThat(petType).isNull();
+    }
+    
+    @Test
+    public void shouldFindSpecialtyById(){
+    	Specialty specialty = this.clinicService.findSpecialtyById(1);
+    	assertThat(specialty.getName()).isEqualTo("radiology");
+    }
+    
+    @Test
+    public void shouldFindAllSpecialtys(){
+        Collection<Specialty> specialties = this.clinicService.findAllSpecialties();
+        Specialty specialty1 = EntityUtils.getById(specialties, Specialty.class, 1);
+        assertThat(specialty1.getName()).isEqualTo("radiology");
+        Specialty specialty3 = EntityUtils.getById(specialties, Specialty.class, 3);
+        assertThat(specialty3.getName()).isEqualTo("dentistry");
+    }
+    
+    @Test
+    @Transactional
+    public void shouldInsertSpecialty() {
+        Collection<Specialty> specialties = this.clinicService.findAllSpecialties();
+        int found = specialties.size();
+
+        Specialty specialty = new Specialty();
+        specialty.setName("dermatologist");
+        
+        this.clinicService.saveSpecialty(specialty);
+        assertThat(specialty.getId().longValue()).isNotEqualTo(0);
+
+        specialties = this.clinicService.findAllSpecialties();
+        assertThat(specialties.size()).isEqualTo(found + 1);
+    }
+    
+    @Test
+    @Transactional
+    public void shouldUpdateSpecialty(){
+    	Specialty specialty = this.clinicService.findSpecialtyById(1);
+    	String oldLastName = specialty.getName();
+        String newLastName = oldLastName + "X";
+        specialty.setName(newLastName);
+        this.clinicService.saveSpecialty(specialty);
+        specialty = this.clinicService.findSpecialtyById(1);
+        assertThat(specialty.getName()).isEqualTo(newLastName);
+    }
+    
+    @Test
+    @Transactional
+    public void shouldDeleteSpecialty(){
+    	Specialty specialty = this.clinicService.findSpecialtyById(1);
+        this.clinicService.deleteSpecialty(specialty);
+        try {
+        	specialty = this.clinicService.findSpecialtyById(1);
+		} catch (Exception e) {
+			specialty = null;
+		}
+        assertThat(specialty).isNull();
+    }
+       
+
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/service/AbstractClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/AbstractClinicServiceTests.java
@@ -22,6 +22,7 @@ import java.util.Date;
 
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
@@ -53,6 +54,7 @@ import org.springframework.transaction.annotation.Transactional;
 public abstract class AbstractClinicServiceTests {
 
     @Autowired
+    @Qualifier("ClinicService")
     protected ClinicService clinicService;
 
     @Test

--- a/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceExtJdbcTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceExtJdbcTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.service;
+
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * <p> Integration test using the jdbc profile.
+ *
+ * @author Vitaliy Fedoriv 
+ * @see AbstractClinicServiceExtTests AbstractClinicServiceExtTests for more details. </p>
+ */
+@ContextConfiguration(locations = {"classpath:spring/business-config.xml"})
+@RunWith(SpringJUnit4ClassRunner.class)
+@ActiveProfiles("jdbc")
+
+public class ClinicServiceExtJdbcTests extends AbstractClinicServiceExtTests {
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceExtJpaTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceExtJpaTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.service;
+
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * <p> Integration test using the jpa profile.
+ *
+ * @author Vitaliy Fedoriv 
+ * @see AbstractClinicServiceExtTests AbstractClinicServiceExtTests for more details. </p>
+ */
+@ContextConfiguration(locations = {"classpath:spring/business-config.xml"})
+@RunWith(SpringJUnit4ClassRunner.class)
+@ActiveProfiles("jpa")
+
+public class ClinicServiceExtJpaTests extends AbstractClinicServiceExtTests {
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceExtSpringDataJpaTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceExtSpringDataJpaTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.service;
+
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * <p> Integration test using the jpa profile.
+ *
+ * @author Vitaliy Fedoriv 
+ * @see AbstractClinicServiceExtTests AbstractClinicServiceExtTests for more details. </p>
+ */
+@ContextConfiguration(locations = {"classpath:spring/business-config.xml"})
+@RunWith(SpringJUnit4ClassRunner.class)
+@ActiveProfiles("spring-data-jpa")
+
+public class ClinicServiceExtSpringDataJpaTests extends AbstractClinicServiceExtTests {
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/web/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/web/OwnerControllerTests.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.service.ClinicService;
 import org.springframework.test.context.ContextConfiguration;
@@ -36,6 +37,7 @@ public class OwnerControllerTests {
     private OwnerController ownerController;
 
     @Autowired
+    @Qualifier("ClinicService")
     private ClinicService clinicService;
 
     private MockMvc mockMvc;

--- a/src/test/java/org/springframework/samples/petclinic/web/PetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/web/PetControllerTests.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.format.support.FormattingConversionServiceFactoryBean;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
@@ -41,6 +42,7 @@ public class PetControllerTests {
     private FormattingConversionServiceFactoryBean formattingConversionServiceFactoryBean;
 
     @Autowired
+    @Qualifier("ClinicService")
     private ClinicService clinicService;
 
     private MockMvc mockMvc;

--- a/src/test/java/org/springframework/samples/petclinic/web/PetTypeFormatterTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/web/PetTypeFormatterTests.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.service.ClinicService;
 
@@ -23,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 public class PetTypeFormatterTests {
 
     @Mock
+    @Qualifier("ClinicService")
     private ClinicService clinicService;
 
     private PetTypeFormatter petTypeFormatter;

--- a/src/test/java/org/springframework/samples/petclinic/web/VetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/web/VetControllerTests.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.samples.petclinic.model.Specialty;
 import org.springframework.samples.petclinic.model.Vet;
@@ -33,6 +34,7 @@ public class VetControllerTests {
     private VetController vetController;
 
     @Autowired
+    @Qualifier("ClinicService")
     private ClinicService clinicService;
 
     private MockMvc mockMvc;

--- a/src/test/java/org/springframework/samples/petclinic/web/VisitControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/web/VisitControllerTests.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.service.ClinicService;
 import org.springframework.test.context.ContextConfiguration;
@@ -33,6 +34,7 @@ public class VisitControllerTests {
     private VisitController visitController;
 
     @Autowired
+    @Qualifier("ClinicService")
     private ClinicService clinicService;
 
     private MockMvc mockMvc;

--- a/src/test/resources/spring/mvc-test-config.xml
+++ b/src/test/resources/spring/mvc-test-config.xml
@@ -4,9 +4,11 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-
-    <bean class="org.mockito.Mockito" factory-method="mock">
+    <bean id="ClinicService" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="org.springframework.samples.petclinic.service.ClinicService"/>
+    </bean>
+    <bean id="ClinicServiceExt" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="org.springframework.samples.petclinic.service.ClinicServiceExt"/>
     </bean>
 
 </beans>


### PR DESCRIPTION
**Proposed changes:**
_________________________________
1. Add new/extended interfaces:
PerRepository -> PetRepositoryExt (extends PerRepository)
(none) -  PetTypeRepositoryExt
etc...
2.  add implementation for this interfaces 
JdbcPetRepositoryExtImpl (implement PetRepositoryExt)
etc...
3. Add new service ClinicServiceExt (extends ClinicService) and implementation class
4. Add new package org.springframework.samples.petclinic.rest with REST controllers
5. Add tests for 1-4
________________________________
**Changes in old files:**
________________________________
1. Add @Qualifier annotation (for correct work @Autowired)
2. Add @JsonIdentityInfo for Pet (resolve infinite loop serialization)
3. Change Pet setOwner() method from protected to public
4. Change scope from private to protected in one JdbcVisitRepositoryImpl method
5. Add @NonEmpty constraint for "name" column in NamedEntity
_________________________________
**Not include / need extensions / discussed / etc...**
_________________________________
1. Proposed REST API "flat":
	/api/owners - GET/POST (get owners list/add new owner)
	/api/owners/1 - GET/PUT/DELETE (get/edit/delete owner)
	/api/pets
	/api/pettypes/
	etc...
"long" variant 
	/owners/{ownerId}/pets/{petId}/visits/ not implemented
2. Very simple exception handling in ExceptionControllerAdvice
	(just return stack trace in request body)
3. Realization delete() method - CASCADE 
	(if you delete owner, you delete all owner pets and owner pets visits)
4. Documentation