### PR TITLE
Correct view as xml url

### DIFF
--- a/src/main/resources/templates/vets/vetList.html
+++ b/src/main/resources/templates/vets/vetList.html
@@ -26,8 +26,7 @@
 
   <table class="table-buttons">
     <tr>
-      <td><a th:href="@{/vets.html}">View
-        as XML</a></td>
+      <td><a th:href="@{/vets.xml}">View as XML</a></td>
       <td><a th:href="@{/vets.json}">View as JSON</a></td>
     </tr>
   </table>


### PR DESCRIPTION
The url for the "View as XML" in the vetList template was pointing to /vets.html instead of vets.xml.