### PR TITLE
Fix incorrect glyphicon name

### DIFF
--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -59,7 +59,7 @@
                       <span>Veterinarians</span>
                   </li>
   
-                  <li th:replace="::menuItem ('/oups','error','trigger a RuntimeException to see how it is handled','th-warning-sign','Error')">
+                  <li th:replace="::menuItem ('/oups','error','trigger a RuntimeException to see how it is handled','warning-sign','Error')">
                       <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
                       <span>Error</span>
                   </li>


### PR DESCRIPTION
Fixes UI bug and thereby making the warning sign glyphicon visible again.

In `layout.html` the glyphicon is incorrectly refered to as `th-warning-sign`. [Reference](http://getbootstrap.com/components/)

