### PR TITLE
Fix date formatting

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
@@ -53,7 +53,7 @@ public class Pet extends NamedEntity {
 
     @Column(name = "birth_date")
     @Temporal(TemporalType.DATE)
-    @DateTimeFormat(pattern = "yyyy/MM/dd")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private Date birthDate;
 
     @ManyToOne

--- a/src/main/java/org/springframework/samples/petclinic/visit/Visit.java
+++ b/src/main/java/org/springframework/samples/petclinic/visit/Visit.java
@@ -42,7 +42,7 @@ public class Visit extends BaseEntity {
      */
     @Column(name = "visit_date")
     @Temporal(TemporalType.TIMESTAMP)
-    @DateTimeFormat(pattern = "yyyy/MM/dd")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private Date date;
 
     /**

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
@@ -75,7 +75,7 @@ public class PetControllerTests {
         mockMvc.perform(post("/owners/{ownerId}/pets/new", TEST_OWNER_ID)
             .param("name", "Betty")
             .param("type", "hamster")
-            .param("birthDate", "2015/02/12")
+            .param("birthDate", "2015-02-12")
         )
             .andExpect(status().is3xxRedirection())
             .andExpect(view().name("redirect:/owners/{ownerId}"));
@@ -85,7 +85,7 @@ public class PetControllerTests {
     public void testProcessCreationFormHasErrors() throws Exception {
         mockMvc.perform(post("/owners/{ownerId}/pets/{petId}/edit", TEST_OWNER_ID, TEST_PET_ID)
             .param("name", "Betty")
-            .param("birthDate", "2015/02/12")
+            .param("birthDate", "2015-02-12")
         )
             .andExpect(model().attributeHasNoErrors("owner"))
             .andExpect(model().attributeHasErrors("pet"))
@@ -106,7 +106,7 @@ public class PetControllerTests {
         mockMvc.perform(post("/owners/{ownerId}/pets/{petId}/edit", TEST_OWNER_ID, TEST_PET_ID)
             .param("name", "Betty")
             .param("type", "hamster")
-            .param("birthDate", "2015/02/12")
+            .param("birthDate", "2015-02-12")
         )
             .andExpect(status().is3xxRedirection())
             .andExpect(view().name("redirect:/owners/{ownerId}"));


### PR DESCRIPTION
This commit fixes an inconsistency in the date formatting in the project.

![differentformatting](https://cloud.githubusercontent.com/assets/1570691/20901884/f4f8ad28-bb34-11e6-9e21-0e89044e66cb.PNG)

Notice how both `yyyy/MM/dd` and `yyyy-MM-dd` is used. However you can't insert `yyyy-MM-dd` 

![rejectformatting](https://cloud.githubusercontent.com/assets/1570691/20901936/257fefba-bb35-11e6-96f7-aec7bdfa8106.PNG)

Since most places uses  `yyyy-MM-dd` I changed the remaining places to unify the date formatting.



