### PR TITLE
Do not fail maven build when git directing is missing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,7 @@
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
           <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties
           </generateGitPropertiesFilename>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
With not .git directory, build is passing:
```
[INFO] --- git-commit-id-plugin:2.2.2:revision (default) @ spring-petclinic ---
[INFO] dotGitDirectory is null, aborting execution!
```