### PR TITLE
fix: make id 'lastName' in findOwners.html unique

### DIFF
--- a/src/main/resources/templates/owners/findOwners.html
+++ b/src/main/resources/templates/owners/findOwners.html
@@ -8,7 +8,7 @@
   <form th:object="${owner}" th:action="@{/owners}" method="get"
     class="form-horizontal" id="search-owner-form">
     <div class="form-group">
-      <div class="control-group" id="lastName">
+      <div class="control-group" id="lastNameGroup">
         <label class="col-sm-2 control-label">Last name </label>
         <div class="col-sm-10">
           <input class="form-control" th:field="*{lastName}" size="30"


### PR DESCRIPTION
Previously the `div.control-group` and the containing `input` shared the same id.
Now the `div` has the id `lastNameGroup`