### PR TITLE
Avoid Maven build error 'dependencies.dependency.version' for org.web…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- Web dependencies -->
+    <!-- Missing in spring-boot-starter-parent: -->
+    <webjars-locator.version>0.32-1</webjars-locator.version>
     <webjars-bootstrap.version>3.3.6</webjars-bootstrap.version>
     <webjars-jquery-ui.version>1.11.4</webjars-jquery-ui.version>
     <webjars-jquery.version>2.2.4</webjars-jquery.version>
@@ -85,6 +87,7 @@
     <dependency>
       <groupId>org.webjars</groupId>
       <artifactId>webjars-locator</artifactId>
+      <version>${webjars-locator.version}</version>
     </dependency>
     <dependency>
       <groupId>org.webjars</groupId>


### PR DESCRIPTION
…jars:webjars-locator:jar is missing. @ line 85, column 17
Please consider pulling in this modification of the POM avoiding the following 
build error 
`[ERROR] 'dependencies.dependency.version' for org.webjars:webjars-locator:jar is missing. @ line 85, column 17`
See full log in 
[mvn-spring-boot:run.log](https://github.com/spring-projects/spring-petclinic/files/1737164/mvn-spring-boot.run.log)