### PR TITLE
Fix including template in layout fragment

### DIFF
--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -71,7 +71,7 @@
   <div class="container-fluid">
       <div class="container xd-container">
   
-          <div th:replace="${template}"/>
+          <th:block th:include="${template}"/>
 
         <br/>
         <br/>


### PR DESCRIPTION
Obvious fix
In the old way of injecting some template, the outer tags were also copied. 