### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/PetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetRepository.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Repository class for <code>Pet</code> domain objects All method names are compliant with Spring Data naming
- * conventions so this interface can easily be extended for Spring Data See here: http://static.springsource.org/spring-data/jpa/docs/current/reference/html/jpa.repositories.html#jpa.query-methods.query-creation
+ * conventions so this interface can easily be extended for Spring Data See here: https://docs.spring.io/spring-data/jpa/docs/current/reference/html/jpa.repositories.html#jpa.query-methods.query-creation
  *
  * @author Ken Krebs
  * @author Juergen Hoeller

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetRepository.java
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Repository class for <code>Vet</code> domain objects All method names are compliant with Spring Data naming
- * conventions so this interface can easily be extended for Spring Data See here: http://static.springsource.org/spring-data/jpa/docs/current/reference/html/jpa.repositories.html#jpa.query-methods.query-creation
+ * conventions so this interface can easily be extended for Spring Data See here: https://docs.spring.io/spring-data/jpa/docs/current/reference/html/jpa.repositories.html#jpa.query-methods.query-creation
  *
  * @author Ken Krebs
  * @author Juergen Hoeller

--- a/src/main/java/org/springframework/samples/petclinic/visit/VisitRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/visit/VisitRepository.java
@@ -23,7 +23,7 @@ import org.springframework.samples.petclinic.model.BaseEntity;
 
 /**
  * Repository class for <code>Visit</code> domain objects All method names are compliant with Spring Data naming
- * conventions so this interface can easily be extended for Spring Data See here: http://static.springsource.org/spring-data/jpa/docs/current/reference/html/jpa.repositories.html#jpa.query-methods.query-creation
+ * conventions so this interface can easily be extended for Spring Data See here: https://docs.spring.io/spring-data/jpa/docs/current/reference/html/jpa.repositories.html#jpa.query-methods.query-creation
  *
  * @author Ken Krebs
  * @author Juergen Hoeller

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout :: layout (~{::body},'error')}">
+<html xmlns:th="https://www.thymeleaf.org" th:replace="~{fragments/layout :: layout (~{::body},'error')}">
 
   <body>
     <img src="../static/resources/images/pets.png" th:src="@{/resources/images/pets.png}"/>

--- a/src/main/resources/templates/owners/createOrUpdateOwnerForm.html
+++ b/src/main/resources/templates/owners/createOrUpdateOwnerForm.html
@@ -1,4 +1,4 @@
-<html xmlns:th="http://www.thymeleaf.org"
+<html xmlns:th="https://www.thymeleaf.org"
   th:replace="~{fragments/layout :: layout (~{::body},'owners')}">
 
 <body>

--- a/src/main/resources/templates/owners/findOwners.html
+++ b/src/main/resources/templates/owners/findOwners.html
@@ -1,4 +1,4 @@
-<html xmlns:th="http://www.thymeleaf.org"
+<html xmlns:th="https://www.thymeleaf.org"
   th:replace="~{fragments/layout :: layout (~{::body},'owners')}">
 
 <body>

--- a/src/main/resources/templates/owners/ownerDetails.html
+++ b/src/main/resources/templates/owners/ownerDetails.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html xmlns:th="http://www.thymeleaf.org"
+<html xmlns:th="https://www.thymeleaf.org"
   th:replace="~{fragments/layout :: layout (~{::body},'owners')}">
 
   <body>

--- a/src/main/resources/templates/owners/ownersList.html
+++ b/src/main/resources/templates/owners/ownersList.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout :: layout (~{::body},'owners')}">
+<html xmlns:th="https://www.thymeleaf.org" th:replace="~{fragments/layout :: layout (~{::body},'owners')}">
 
   <body>
 

--- a/src/main/resources/templates/pets/createOrUpdatePetForm.html
+++ b/src/main/resources/templates/pets/createOrUpdatePetForm.html
@@ -1,4 +1,4 @@
-<html xmlns:th="http://www.thymeleaf.org"
+<html xmlns:th="https://www.thymeleaf.org"
   th:replace="~{fragments/layout :: layout (~{::body},'owners')}">
 
 <body>

--- a/src/main/resources/templates/pets/createOrUpdateVisitForm.html
+++ b/src/main/resources/templates/pets/createOrUpdateVisitForm.html
@@ -1,4 +1,4 @@
-<html xmlns:th="http://www.thymeleaf.org"
+<html xmlns:th="https://www.thymeleaf.org"
   th:replace="~{fragments/layout :: layout (~{::body},'owners')}">
 
 <body>

--- a/src/main/resources/templates/vets/vetList.html
+++ b/src/main/resources/templates/vets/vetList.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html xmlns:th="http://www.thymeleaf.org"
+<html xmlns:th="https://www.thymeleaf.org"
   th:replace="~{fragments/layout :: layout (~{::body},'vets')}">
 
 <body>

--- a/src/main/resources/templates/welcome.html
+++ b/src/main/resources/templates/welcome.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/layout :: layout (~{::body},'home')}">
+<html xmlns:th="https://www.thymeleaf.org" th:replace="~{fragments/layout :: layout (~{::body},'home')}">
 
   <body>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://static.springsource.org/spring-data/jpa/docs/current/reference/html/jpa.repositories.html (301) with 3 occurrences migrated to:  
  https://docs.spring.io/spring-data/jpa/docs/current/reference/html/jpa.repositories.html ([https](https://static.springsource.org/spring-data/jpa/docs/current/reference/html/jpa.repositories.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.thymeleaf.org with 9 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 2 occurrences
* http://localhost:8080/ with 1 occurrences