### PR TITLE
Fixed 14 code smells detected by SonarQube

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/system/CacheConfiguration.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/CacheConfiguration.java
@@ -34,9 +34,7 @@ class CacheConfiguration {
 
 	@Bean
 	public JCacheManagerCustomizer petclinicCacheConfigurationCustomizer() {
-		return cm -> {
-			cm.createCache("vets", cacheConfiguration());
-		};
+		return cm -> cm.createCache("vets", cacheConfiguration());
 	}
 
 	/**

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -30,10 +30,10 @@ import java.util.Map;
 @Controller
 class VetController {
 
-	private final VetRepository vets;
+	private final VetRepository vetRepository;
 
 	public VetController(VetRepository clinicService) {
-		this.vets = clinicService;
+		this.vetRepository = clinicService;
 	}
 
 	@GetMapping("/vets.html")
@@ -41,7 +41,7 @@ class VetController {
 		// Here we are returning an object of type 'Vets' rather than a collection of Vet
 		// objects so it is simpler for Object-Xml mapping
 		Vets vets = new Vets();
-		vets.getVetList().addAll(this.vets.findAll());
+		vets.getVetList().addAll(this.vetRepository.findAll());
 		model.put("vets", vets);
 		return "vets/vetList";
 	}
@@ -51,7 +51,7 @@ class VetController {
 		// Here we are returning an object of type 'Vets' rather than a collection of Vet
 		// objects so it is simpler for JSon/Object mapping
 		Vets vets = new Vets();
-		vets.getVetList().addAll(this.vets.findAll());
+		vets.getVetList().addAll(this.vetRepository.findAll());
 		return vets;
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetRepository.java
@@ -15,12 +15,11 @@
  */
 package org.springframework.samples.petclinic.vet;
 
-import java.util.Collection;
-
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.dao.DataAccessException;
 import org.springframework.data.repository.Repository;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
 
 /**
  * Repository class for <code>Vet</code> domain objects All method names are compliant
@@ -41,6 +40,6 @@ public interface VetRepository extends Repository<Vet, Integer> {
 	 */
 	@Transactional(readOnly = true)
 	@Cacheable("vets")
-	Collection<Vet> findAll() throws DataAccessException;
+	Collection<Vet> findAll();
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/vet/Vets.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Vets.java
@@ -30,14 +30,14 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 public class Vets {
 
-	private List<Vet> vets;
+	private List<Vet> vetList;
 
 	@XmlElement
 	public List<Vet> getVetList() {
-		if (vets == null) {
-			vets = new ArrayList<>();
+		if (vetList == null) {
+			vetList = new ArrayList<>();
 		}
-		return vets;
+		return vetList;
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/visit/VisitRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/visit/VisitRepository.java
@@ -15,11 +15,10 @@
  */
 package org.springframework.samples.petclinic.visit;
 
-import java.util.List;
-
-import org.springframework.dao.DataAccessException;
 import org.springframework.data.repository.Repository;
 import org.springframework.samples.petclinic.model.BaseEntity;
+
+import java.util.List;
 
 /**
  * Repository class for <code>Visit</code> domain objects All method names are compliant
@@ -39,7 +38,7 @@ public interface VisitRepository extends Repository<Visit, Integer> {
 	 * @param visit the <code>Visit</code> to save
 	 * @see BaseEntity#isNew
 	 */
-	void save(Visit visit) throws DataAccessException;
+	void save(Visit visit);
 
 	List<Visit> findByPetId(Integer petId);
 

--- a/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
@@ -53,7 +53,7 @@ class ValidatorTests {
 
 		assertThat(constraintViolations).hasSize(1);
 		ConstraintViolation<Person> violation = constraintViolations.iterator().next();
-		assertThat(violation.getPropertyPath().toString()).isEqualTo("firstName");
+		assertThat(violation.getPropertyPath()).hasToString("firstName");
 		assertThat(violation.getMessage()).isEqualTo("must not be empty");
 	}
 

--- a/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceTests.java
@@ -112,10 +112,10 @@ class ClinicServiceTests {
 		owner.setCity("Wollongong");
 		owner.setTelephone("4444444444");
 		this.owners.save(owner);
-		assertThat(owner.getId().longValue()).isNotEqualTo(0);
+		assertThat(owner.getId().longValue()).isNotZero();
 
 		owners = this.owners.findByLastName("Schultz");
-		assertThat(owners.size()).isEqualTo(found + 1);
+		assertThat(owners).hasSize(found + 1);
 	}
 
 	@Test


### PR DESCRIPTION
Code smells described in https://github.com/spring-projects/spring-petclinic/issues/662. The pull request fixes the listed issues by adhering to sonar Java rules.

- Lambdas containing only one statement should not nest this statement in a block [RSPEC-1602](https://rules.sonarsource.com/java/RSPEC-1602)

- Local variables should not shadow class fields [RSPEC-1117](https://rules.sonarsource.com/java/RSPEC-1117)

- a RuntimeException, or one of its descendants should not be declared in functions. DataAccessException is also a RuntimeException [RSPEC-1130](https://rules.sonarsource.com/java/RSPEC-1130)

- A field should not duplicate the name of its containing class, [RSPEC-1700](https://rules.sonarsource.com/java/RSPEC-1700)

- Chained AssertJ assertions should be simplified to the corresponding dedicated assertion [RSPEC-5838](https://rules.sonarsource.com/java/RSPEC-5838)