### PR TITLE
Do not fail packaging if repo info is absent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,7 @@
           <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties
           </generateGitPropertiesFilename>
           <failOnNoGitDirectory>false</failOnNoGitDirectory>
+          <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
As part of a process to build a BOSH release, I encountered the error
below while running `./mvnw package`:

```
[ERROR] Failed to execute goal pl.project13.maven:git-commit-id-plugin:3.0.1:revision (default) on project spring-petclinic: Could not complete Mojo execution...: Error: Could not get HEAD Ref, are you sure you have set the dotGitDirectory property of this plugin to a valid path? -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

That's because we are just interested on the source files for the BOSH
release, we don't care about repo metadata (so we exclude them).

Going through the [git-commit-id-maven-plugin
docs](https://github.com/git-commit-id/git-commit-id-maven-plugin/blob/master/maven/docs/using-the-plugin.md)
we learned it is possible to prevent the failure above via
configuration.

We propose then to set
`<failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>`,
enabling use cases similar to ours.

FWIW `failOnNoGitDirectory` is already set to false.