### PR TITLE
Update docker-compose.yml to version 2.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,15 @@
-mysql:
-  image: mysql:5.7
-  ports:
-    - "3306:3306"
-  environment:
-    - MYSQL_ROOT_PASSWORD=
-    - MYSQL_ALLOW_EMPTY_PASSWORD=true
-    - MYSQL_USER=petclinic
-    - MYSQL_PASSWORD=petclinic
-    - MYSQL_DATABASE=petclinic
-  volumes:
-    - "./conf.d:/etc/mysql/conf.d:ro"
+version: "2.2"
+
+services:
+  mysql:
+    image: mysql:5.7
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=
+      - MYSQL_ALLOW_EMPTY_PASSWORD=true
+      - MYSQL_USER=petclinic
+      - MYSQL_PASSWORD=petclinic
+      - MYSQL_DATABASE=petclinic
+    volumes:
+      - "./conf.d:/etc/mysql/conf.d:ro"


### PR DESCRIPTION
The current docker-compose.yml is still in version 1, which is
deprecated: https://docs.docker.com/compose/compose-file/compose-versioning/

So if you try to run `docker-compose up` with a recent version of
docker-compose, the following error occurs:
```
    (root) Additional property mysql is not allowed
```

Version 2.2 was chosen because it's not deprecated, but it also has been
released some time ago: Compose version 2.2 requires docker engine
version 1.13.0, which was released on 2017-01-18. So, with this version,
hopefully no users will have any issues either with deprecation warnings
or with a version that is not yet supported by their docker-engine.