### PR TITLE
Update readme.md to show that Java 11 is required

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 <a href="https://speakerdeck.com/michaelisvy/spring-petclinic-sample-application">See the presentation here</a>
 
 ## Running petclinic locally
-Petclinic is a [Spring Boot](https://spring.io/guides/gs/spring-boot) application built using [Maven](https://spring.io/guides/gs/maven/). You can build a jar file and run it from the command line (it should work just as well with Java 11 or 17):
+Petclinic is a [Spring Boot](https://spring.io/guides/gs/spring-boot) application built using [Maven](https://spring.io/guides/gs/maven/). You can build a jar file and run it from the command line (it should work just as well with Java 11 or newer):
 
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ There is a `petclinic.css` in `src/main/resources/static/resources/css`. It was 
 
 ### Prerequisites
 The following items should be installed in your system:
-* Java 8 or newer (full JDK not a JRE).
+* Java 11 or newer (full JDK not a JRE).
 * git command line tool (https://help.github.com/articles/set-up-git)
 * Your preferred IDE 
   * Eclipse with the m2e plugin. Note: when m2e is available, there is an m2 icon in `Help -> About` dialog. If m2e is

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 <a href="https://speakerdeck.com/michaelisvy/spring-petclinic-sample-application">See the presentation here</a>
 
 ## Running petclinic locally
-Petclinic is a [Spring Boot](https://spring.io/guides/gs/spring-boot) application built using [Maven](https://spring.io/guides/gs/maven/). You can build a jar file and run it from the command line (it should work just as well with Java 8, 11 or 17):
+Petclinic is a [Spring Boot](https://spring.io/guides/gs/spring-boot) application built using [Maven](https://spring.io/guides/gs/maven/). You can build a jar file and run it from the command line (it should work just as well with Java 11 or 17):
 
 
 ```


### PR DESCRIPTION
Description
--
> mvnw spring-boot:run

When executing the command on Java 8, an error occurs as below. 

> Caused` by: org.apache.maven.plugin.PluginContainerException: An API incompatibility was encountered while executing io.spring.javaformat:spring-javaformat-maven-plugin:0.0.31:validate: java.lang.UnsupportedClassVersionError: io/spring/javaformat/eclipse/jdt/jdk11/internal/formatter/DefaultCodeFormatter has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0

This project doesn't work on Java 8. thus I removed Java 8.
