### PR TITLE
Resource bundle not included in native image

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/PetClinicRuntimeHints.java
+++ b/src/main/java/org/springframework/samples/petclinic/PetClinicRuntimeHints.java
@@ -24,6 +24,7 @@ public class PetClinicRuntimeHints implements RuntimeHintsRegistrar {
 	@Override
 	public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
 		hints.resources().registerPattern("db/*"); // https://github.com/spring-projects/spring-boot/issues/32654
+		hints.resources().registerPattern("messages/*");
 		hints.resources().registerPattern("META-INF/resources/webjars/*");
 	}
 


### PR DESCRIPTION
The resource bundle was not included in the native hints which would cause the text to not be displayed in the right language.