### PR TITLE
Build with GraalVM Native Image.

### DIFF
--- a/.github/workflows/maven-build-native.yml
+++ b/.github/workflows/maven-build-native.yml
@@ -1,0 +1,30 @@
+name: Native CI with Maven and GraalVM Native Image
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '17' ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up GraalVM JDK ${{matrix.java}}
+        uses: graalvm/setup-graalvm@v1
+        with:
+          version: 'latest'
+          java-version: ${{matrix.java}}
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: maven
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
+      - name: Build with Maven Wrapper
+        run: ./mvnw -B -ntp -Pnative native:compile

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -18,9 +18,9 @@ jobs:
         java: [ '17' ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{matrix.java}}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{matrix.java}}
           distribution: 'adopt'

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -26,4 +26,4 @@ jobs:
           distribution: 'adopt'
           cache: maven
       - name: Build with Maven Wrapper
-        run: ./mvnw -B package
+        run: ./mvnw -B -ntp package


### PR DESCRIPTION
This PR adds a new `maven-build-native.yml` workflow that builds Spring PetClinic with GraalVM Native Image.
I also used this opportunity to upgrade the `checkout` and `setup-java` actions and to add `--no-transfer-progress` for a cleaner build log.