### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
 	"extensions": [
 		"vscjava.vscode-java-pack",
 		"redhat.vscode-xml",
-		"pivotal.vscode-boot-dev-pack",
+		"vmware.vscode-boot-dev-pack",
 		"mhutchie.git-graph"
 	],
 	"forwardPorts": [8080],


### PR DESCRIPTION
publisher id of vscode-boot-dev-pack has been changed from `pivotal` to `vmware`.