### PR TITLE
Fix crashcontroller test

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
@@ -43,11 +43,14 @@ import org.springframework.http.ResponseEntity;
 // NOT Waiting https://github.com/spring-projects/spring-boot/issues/5574, int
 // test!!!
 @SuppressWarnings("java:S2970") // contradicts "java:S5838"
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = { "server.error.include-message=ALWAYS" })
+@SpringBootTest(webEnvironment = RANDOM_PORT,
+		// this ("somehow", significantly) "differs" from "non-test":
+		properties = { "server.error.include-message=ALWAYS" })
 class CrashControllerIntegrationTests {
 
-	// i think this is the "lightest" (and quickest context), that we can bootstrap,
-	// see: https://spring.io/guides/gs/multi-module/
+	// i think this is the "lightest" (sub package) and quickest (who wants to
+	// exclude auto config: welcome!) context, that we
+	// can bootstrap, see: https://spring.io/guides/gs/multi-module/
 	@SpringBootApplication
 	static class TestConfiguration {
 

--- a/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.system;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Integration Test for {@link CrashController}.
+ *
+ * @author Alex Lutz
+ */
+// NOT Waiting https://github.com/spring-projects/spring-boot/issues/5574, int
+// test!!!
+@SuppressWarnings("java:S2970") // contradicts "java:S5838"
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = { "server.error.include-message=ALWAYS" })
+class CrashControllerIntegrationTests {
+
+	// i think this is the "lightest" (and quickest context), that we can bootstrap,
+	// see: https://spring.io/guides/gs/multi-module/
+	@SpringBootApplication
+	static class TestConfiguration {
+
+	}
+
+	@Value(value = "${local.server.port}")
+	private int port;
+
+	@Autowired
+	private TestRestTemplate restTpl;
+
+	@Test
+	@SuppressWarnings("rawtypes")
+	void testTriggerExceptionJson() {
+		ResponseEntity<Map> resp = restTpl.getForEntity("http://localhost:" + port + "/oups", Map.class);
+		assertThat(resp).isNotNull();
+		assertThat(resp.getStatusCode().is5xxServerError());
+		assertThat(resp.getBody().containsKey("timestamp"));
+		assertThat(resp.getBody().containsKey("status"));
+		assertThat(resp.getBody().containsKey("error"));
+		assertThat(resp.getBody()).containsEntry("message",
+				"Expected: controller used to showcase what happens when an exception is thrown");
+		assertThat(resp.getBody()).containsEntry("path", "/oups");
+	}
+
+	@Test
+	void testTriggerExceptionHtml() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setAccept(List.of(MediaType.TEXT_HTML));
+		ResponseEntity<String> resp = restTpl.exchange("http://localhost:" + port + "/oups", HttpMethod.GET,
+				new HttpEntity<>(headers), String.class);
+		assertThat(resp).isNotNull();
+		assertThat(resp.getStatusCode().is5xxServerError());
+		assertNotNull(resp.getBody());
+		// html:
+		assertThat(resp.getBody()).containsSubsequence("<body>", "<h2>Something happened...</h2>",
+				"<p>Expected: controller used to showcase what happens when an exception is thrown</p>", "</body>");
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
@@ -17,7 +17,6 @@
 package org.springframework.samples.petclinic.system;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 import java.util.List;
@@ -84,7 +83,7 @@ class CrashControllerIntegrationTests {
 				new HttpEntity<>(headers), String.class);
 		assertThat(resp).isNotNull();
 		assertThat(resp.getStatusCode().is5xxServerError());
-		assertNotNull(resp.getBody());
+		assertThat(resp.getBody()).isNotNull();
 		// html:
 		assertThat(resp.getBody()).containsSubsequence("<body>", "<h2>Something happened...</h2>",
 				"<p>Expected: controller used to showcase what happens when an exception is thrown</p>", "</body>");

--- a/src/test/java/org/springframework/samples/petclinic/system/CrashControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/CrashControllerTests.java
@@ -16,35 +16,30 @@
 
 package org.springframework.samples.petclinic.system;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.web.servlet.MockMvc;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@link CrashController}
  *
- * @author Colin But
+ * @author Colin But, Alex Lutz
  */
-// Waiting https://github.com/spring-projects/spring-boot/issues/5574
-@Disabled
-@WebMvcTest(controllers = CrashController.class)
+// Waiting https://github.com/spring-projects/spring-boot/issues/5574 ..good
+// luck ((plain(st) UNIT test)! :)
 class CrashControllerTests {
 
-	@Autowired
-	private MockMvc mockMvc;
+	CrashController testee = new CrashController();
 
 	@Test
 	void testTriggerException() throws Exception {
-		mockMvc.perform(get("/oups"))
-			.andExpect(view().name("exception"))
-			.andExpect(model().attributeExists("exception"))
-			.andExpect(forwardedUrl("exception"))
-			.andExpect(status().isOk());
+		RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+			testee.triggerException();
+		});
+
+		assertEquals("Expected: controller used to showcase what happens when an exception is thrown",
+				thrown.getMessage());
 	}
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/system/CrashControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/CrashControllerTests.java
@@ -24,7 +24,8 @@ import org.junit.jupiter.api.Test;
 /**
  * Test class for {@link CrashController}
  *
- * @author Colin But, Alex Lutz
+ * @author Colin But
+ * @author Alex Lutz
  */
 // Waiting https://github.com/spring-projects/spring-boot/issues/5574 ..good
 // luck ((plain(st) UNIT test)! :)


### PR DESCRIPTION
It is hard to summarize the where/why/when, but: `@WebMvcTest` is not (comparable with) a "full blown" (embedded) spring-boot application... (And i fear, we will have to wait a while, till that happens)

So I decided, to introduce:
- a "very slim" unit test
- and a (slim as possible, "full blown") integration test