### PR TITLE
Remove unnecessary autocrlf guidance for Windows users

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,8 +29,6 @@ Or you can run it from Maven directly using the Spring Boot Maven plugin. If you
 ./mvnw spring-boot:run
 ```
 
-> NOTE: Windows users should set `git config core.autocrlf true` to avoid format assertions failing the build (use `--global` to set that flag globally).
-
 > NOTE: If you prefer to use Gradle, you can build the app using `./gradlew build` and look for the jar file in `build/libs`.
 
 ## Building a Container


### PR DESCRIPTION
The line-endings issue has been resolved as of spring-javaformat version 0.0.36 so Windows users' terminals are no longer painted red with format violations if they've configured LF line endings.