### PR TITLE
Change validation annotations and whitespace handling

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Person.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Person.java
@@ -17,7 +17,7 @@ package org.springframework.samples.petclinic.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 
 /**
  * Simple JavaBean domain object representing an person.
@@ -28,11 +28,11 @@ import jakarta.validation.constraints.NotEmpty;
 public class Person extends BaseEntity {
 
 	@Column(name = "first_name")
-	@NotEmpty
+	@NotBlank
 	private String firstName;
 
 	@Column(name = "last_name")
-	@NotEmpty
+	@NotBlank
 	private String lastName;
 
 	public String getFirstName() {

--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -31,7 +31,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Digits;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 
 /**
  * Simple JavaBean domain object representing an owner.
@@ -47,15 +47,15 @@ import jakarta.validation.constraints.NotEmpty;
 public class Owner extends Person {
 
 	@Column(name = "address")
-	@NotEmpty
+	@NotBlank
 	private String address;
 
 	@Column(name = "city")
-	@NotEmpty
+	@NotBlank
 	private String city;
 
 	@Column(name = "telephone")
-	@NotEmpty
+	@NotBlank
 	@Digits(fraction = 0, integer = 10)
 	private String telephone;
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -95,7 +95,7 @@ class PetController {
 
 	@PostMapping("/pets/new")
 	public String processCreationForm(Owner owner, @Valid Pet pet, BindingResult result, ModelMap model) {
-		if (StringUtils.hasLength(pet.getName()) && pet.isNew() && owner.getPet(pet.getName(), true) != null) {
+		if (StringUtils.hasText(pet.getName()) && pet.isNew() && owner.getPet(pet.getName(), true) != null) {
 			result.rejectValue("name", "duplicate", "already exists");
 		}
 
@@ -127,7 +127,7 @@ class PetController {
 		String petName = pet.getName();
 
 		// checking if the pet name already exist for the owner
-		if (StringUtils.hasLength(petName)) {
+		if (StringUtils.hasText(petName)) {
 			Pet existingPet = owner.getPet(petName.toLowerCase(), false);
 			if (existingPet != null && existingPet.getId() != pet.getId()) {
 				result.rejectValue("name", "duplicate", "already exists");

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
@@ -38,7 +38,7 @@ public class PetValidator implements Validator {
 		Pet pet = (Pet) obj;
 		String name = pet.getName();
 		// name validation
-		if (!StringUtils.hasLength(name)) {
+		if (!StringUtils.hasText(name)) {
 			errors.rejectValue("name", REQUIRED, REQUIRED);
 		}
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/Visit.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Visit.java
@@ -23,7 +23,7 @@ import org.springframework.samples.petclinic.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 
 /**
  * Simple JavaBean domain object representing a visit.
@@ -39,7 +39,7 @@ public class Visit extends BaseEntity {
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
 	private LocalDate date;
 
-	@NotEmpty
+	@NotBlank
 	private String description;
 
 	/**

--- a/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
@@ -54,7 +54,7 @@ class ValidatorTests {
 		assertThat(constraintViolations).hasSize(1);
 		ConstraintViolation<Person> violation = constraintViolations.iterator().next();
 		assertThat(violation.getPropertyPath().toString()).isEqualTo("firstName");
-		assertThat(violation.getMessage()).isEqualTo("must not be empty");
+		assertThat(violation.getMessage()).isEqualTo("must not be blank");
 	}
 
 }


### PR DESCRIPTION
Replaced the @NotEmpty annotation with @NotBlank for improved validation accuracy, ensuring that the field is not only present but also not consisting of only whitespaces.

Additionally, updated the validation checks to use StringUtils.hasText instead of StringUtils.hasLength to account for whitespace-only values as well.