### PR TITLE
Changes to application.properties file to open h2-console in browser. 

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,8 @@
 database=h2
 spring.sql.init.schema-locations=classpath*:db/${database}/schema.sql
 spring.sql.init.data-locations=classpath*:db/${database}/data.sql
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
 
 # Web
 spring.thymeleaf.mode=HTML


### PR DESCRIPTION
Following README  was trying to access h2 console using _http://localhost:8080/h2-console_ . The state of the code at the moment doesn't allow to do so (at least I haven't found out the way). Adding two lines of prop did the trick. 