### PR TITLE
Checkstyle NoHttp suppressed for all log files

### DIFF
--- a/src/checkstyle/nohttp-checkstyle-suppressions.xml
+++ b/src/checkstyle/nohttp-checkstyle-suppressions.xml
@@ -6,6 +6,5 @@
 	<suppress files="node_modules/.*" checks=".*"/>
 	<suppress files="node/.*" checks=".*"/>
 	<suppress files="build/.*" checks=".*"/>
-	<suppress files="[\\/]build.log" checks="NoHttp"/>
-	<suppress files=".+\.(jar|git|ico|p12|gif|jks|jpg|svg)" checks="NoHttp"/>
+	<suppress files=".+\.(jar|git|ico|p12|gif|jks|jpg|svg|log)" checks="NoHttp"/>
 </suppressions>


### PR DESCRIPTION
`NoHttp` rule should presumably be focused on files that might be committed in to the repository. This change expands an existing rule suppression to cover all `.log` files rather than just one specific `build.log`. This avoids log files written by external tools from failing `./mvnw test` execution.