### PR TITLE
Running `./gradlew test` should not require Docker

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
@@ -31,6 +31,7 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.samples.petclinic.vet.VetRepository;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.aot.DisabledInAotMode;
 import org.springframework.web.client.RestTemplate;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -40,6 +41,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ActiveProfiles("mysql")
 @Testcontainers(disabledWithoutDocker = true)
 @DisabledInNativeImage
+@DisabledInAotMode
 class MySqlIntegrationTests {
 
 	@ServiceConnection


### PR DESCRIPTION
Annotated `MySqlIntegrationTests` with `@DisabledInAotMode` to avoid requiring Docker.

Tested by running within Docker (ironically) using the following Dockerfile in the project root:

```Dockerfile
FROM gradle:8.4-jdk17
WORKDIR /work
COPY . .
RUN gradle test
```

Before `docker build .` fails ending:

```
26.70 
26.70 > Task :processTestAot FAILED
26.73 
26.73 FAILURE: Build failed with an exception.
26.73 
26.73 * What went wrong:
26.73 Execution failed for task ':processTestAot'.
26.73 > Process 'command '/opt/java/openjdk/bin/java'' finished with non-zero exit value 1
26.73 
26.73 * Try:
26.73 > Run with --stacktrace option to get the stack trace.
26.73 > Run with --info or --debug option to get more log output.
26.73 > Run with --scan to get full insights.
26.73 > Get more help at https://help.gradle.org.
26.73 
26.73 Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
26.73 
26.73 You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
26.73 
26.73 For more on this, please refer to https://docs.gradle.org/8.4/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
26.73 4 actionable tasks: 2 executed, 2 up-to-date
26.73 
26.73 BUILD FAILED in 26s
------
Dockerfile:4
--------------------
   2 |     WORKDIR /work
   3 |     COPY . .
   4 | >>> RUN gradle test
   5 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c gradle test" did not complete successfully: exit code: 1
```

After `docker build .` passes, ending:

```
 => [3/4] COPY . .                                                                                                                                                                                    0.4s
 => [4/4] RUN gradle test                                                                                                                                                                            65.4s
 => exporting to image                                                                                                                                                                                0.5s
 => => exporting layers                                                                                                                                                                               0.5s
 => => writing image sha256:0fc88e7f71d309ee256cfec71061df1f797acd72ea4f7db47ca87f0623acbc50                                                                                                          0.0s 
```

Closes https://github.com/spring-projects/spring-petclinic/issues/1307