### PR TITLE
Bump actions version to latest version (@v4)

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -18,9 +18,9 @@ jobs:
         java: [ '17' ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{matrix.java}}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{matrix.java}}
           distribution: 'adopt'


### PR DESCRIPTION
This PR bump the version of `actions/checkout` and `actions/setup-java` to v4