### PR TITLE
Add Gradle files indentation to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,6 @@ indent_style = space
 
 [*.{html,sql,less}]
 indent_size = 2
+
+[*.gradle]
+indent_size = 2


### PR DESCRIPTION
To prevent accidental changes when working on Gradle changes.