### PR TITLE
Add user friendly validation messages

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Person.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Person.java
@@ -28,11 +28,11 @@ import jakarta.validation.constraints.NotBlank;
 public class Person extends BaseEntity {
 
 	@Column(name = "first_name")
-	@NotBlank
+	@NotBlank(message = "First Name cannot be blank")
 	private String firstName;
 
 	@Column(name = "last_name")
-	@NotBlank
+	@NotBlank(message = "Last Name cannot be blank")
 	private String lastName;
 
 	public String getFirstName() {

--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -18,6 +18,7 @@ package org.springframework.samples.petclinic.owner;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.validation.constraints.Pattern;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.samples.petclinic.model.Person;
 import org.springframework.util.Assert;
@@ -47,16 +48,16 @@ import jakarta.validation.constraints.NotBlank;
 public class Owner extends Person {
 
 	@Column(name = "address")
-	@NotBlank
+	@NotBlank(message = "Address cannot be blank")
 	private String address;
 
 	@Column(name = "city")
-	@NotBlank
+	@NotBlank(message = "City cannot be blank")
 	private String city;
 
 	@Column(name = "telephone")
-	@NotBlank
-	@Digits(fraction = 0, integer = 10)
+	@NotBlank(message = "Telephone cannot be blank")
+	@Pattern(regexp = "\\d{10}", message = "Telephone must be a 10-digit number")
 	private String telephone;
 
 	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)

--- a/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
@@ -54,7 +54,7 @@ class ValidatorTests {
 		assertThat(constraintViolations).hasSize(1);
 		ConstraintViolation<Person> violation = constraintViolations.iterator().next();
 		assertThat(violation.getPropertyPath().toString()).isEqualTo("firstName");
-		assertThat(violation.getMessage()).isEqualTo("must not be blank");
+		assertThat(violation.getMessage()).isEqualTo("First Name cannot be blank");
 	}
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -117,7 +117,7 @@ class OwnerControllerTests {
 				.param("lastName", "Bloggs")
 				.param("address", "123 Caramel Street")
 				.param("city", "London")
-				.param("telephone", "01316761638"))
+				.param("telephone", "0123456789"))
 			.andExpect(status().is3xxRedirection());
 	}
 
@@ -188,7 +188,7 @@ class OwnerControllerTests {
 				.param("lastName", "Bloggs")
 				.param("address", "123 Caramel Street")
 				.param("city", "London")
-				.param("telephone", "01616291589"))
+				.param("telephone", "0123456789"))
 			.andExpect(status().is3xxRedirection())
 			.andExpect(view().name("redirect:/owners/{ownerId}"));
 	}


### PR DESCRIPTION
As described in #1351 the validation messages are not very user-friendly. Additionally the validation of the telephone number (which is a String value) with `@Digits` is faulty because leading zeros are ignored when converting from String to BigDecimal in the [DigitsValidator](https://github.com/hibernate/hibernate-validator/blob/7.0.5.Final/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/DigitsValidatorForCharSequence.java#L60). This faulty behaviour was also visible in the [tests](https://github.com/spring-projects/spring-petclinic/blob/836d111e9950f6abedb4fef7b4a94941b8dfedd8/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java#L120) where an 11 digit number was parsed as the telephone number.
```
	@Test
	void testProcessCreationFormSuccess() throws Exception {
		mockMvc
			.perform(post("/owners/new").param("firstName", "Joe")
				.param("lastName", "Bloggs")
				.param("address", "123 Caramel Street")
				.param("city", "London")
				.param("telephone", "01316761638"))
			.andExpect(status().is3xxRedirection());
	}
```
These caused the failing tests in #1361. 