### PR TITLE
test: complete assertions

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
@@ -35,6 +35,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
@@ -68,10 +69,10 @@ class CrashControllerIntegrationTests {
 				new ParameterizedTypeReference<Map<String, Object>>() {
 				});
 		assertThat(resp).isNotNull();
-		assertThat(resp.getStatusCode().is5xxServerError());
-		assertThat(resp.getBody().containsKey("timestamp"));
-		assertThat(resp.getBody().containsKey("status"));
-		assertThat(resp.getBody().containsKey("error"));
+		assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+		assertThat(resp.getBody()).containsKey("timestamp");
+		assertThat(resp.getBody()).containsKey("status");
+		assertThat(resp.getBody()).containsKey("error");
 		assertThat(resp.getBody()).containsEntry("message",
 				"Expected: controller used to showcase what happens when an exception is thrown");
 		assertThat(resp.getBody()).containsEntry("path", "/oups");
@@ -84,7 +85,7 @@ class CrashControllerIntegrationTests {
 		ResponseEntity<String> resp = rest.exchange("http://localhost:" + port + "/oups", HttpMethod.GET,
 				new HttpEntity<>(headers), String.class);
 		assertThat(resp).isNotNull();
-		assertThat(resp.getStatusCode().is5xxServerError());
+		assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
 		assertThat(resp.getBody()).isNotNull();
 		// html:
 		assertThat(resp.getBody()).containsSubsequence("<body>", "<h2>", "Something happened...", "</h2>", "<p>",


### PR DESCRIPTION
According to the [AssertJ](https://assertj.github.io/doc/#assertj-core-assertions-guide) library, the `assertThat()` method must be followed by an assertion invocation, otherwise what is intended to be a test doesn't actually verify anything.