### PR TITLE
Including CycloneDX for SBOM generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
   id 'org.springframework.boot' version '3.3.0'
   id 'io.spring.dependency-management' version '1.1.5'
   id 'org.graalvm.buildtools.native' version '0.10.2'
+  id 'org.cyclonedx.bom' version '1.8.2'
   id 'io.spring.javaformat' version '0.0.41'
   id "io.spring.nohttp" version "0.0.11"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -257,8 +257,8 @@
         </executions>
       </plugin>
 
-      <!-- Spring Boot Actuator displays build-related information if a git.properties
-        file is present at the classpath -->
+      <!-- Spring Boot Actuator displays build-related information if a git.properties file is
+      present at the classpath -->
       <plugin>
         <groupId>io.github.git-commit-id</groupId>
         <artifactId>git-commit-id-maven-plugin</artifactId>
@@ -266,6 +266,12 @@
           <failOnNoGitDirectory>false</failOnNoGitDirectory>
           <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
         </configuration>
+      </plugin>
+      <!-- Spring Boot Actuator displays sbom-related information if a CycloneDX SBOM file is
+      present at the classpath -->
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
Including the Cyclone DX plugins to generate the SBOM file for spring-boot-actuator.

While maven will work fine even if you run `mvn spring-boot:run` for Gradle builds, you will need to build the `bootJar` first and run the artifact to access `/actuator/sbom` and `/actuator/sbom/application`.

See more info regarding the Gradle issue here: https://github.com/spring-projects/spring-boot/issues/40890