### PR TITLE
Utilize active profiles with the help of spring.docker.compose.profiles.active property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-docker-compose</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
@@ -221,7 +220,7 @@
         <artifactId>spring-boot-maven-plugin</artifactId>
         <executions>
           <execution>
-            <!-- Spring Boot Actuator displays build-related information 
+            <!-- Spring Boot Actuator displays build-related information
               if a META-INF/build-info.properties file is present -->
             <goals>
               <goal>build-info</goal>
@@ -385,7 +384,7 @@
       <build>
         <pluginManagement>
           <plugins>
-            <!-- This plugin's configuration is used to store Eclipse m2e settings 
+            <!-- This plugin's configuration is used to store Eclipse m2e settings
               only. It has no influence on the Maven build itself. -->
             <plugin>
               <groupId>org.eclipse.m2e</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,9 @@ spring.messages.basename=messages/messages
 # Actuator
 management.endpoints.web.exposure.include=*
 
+# Docker compose
+spring.docker.compose.profiles.active=${spring.profiles.active}
+
 # Logging
 logging.level.org.springframework=INFO
 # logging.level.org.springframework.web=DEBUG


### PR DESCRIPTION
In order to avoid manual docker-compose run `spring-boot-docker-compose` scope was extended and `spring.docker.compose.profiles.active` set to accept active profile(s).

So after changes it's possible to run petclinic app just with:
```
 ./mvnw spring-boot:run "-Dspring-boot.run.arguments=--spring.profiles.active=postgres"
```
or with IDE adding corresponsding profile. and let `spring-docker-compose` automatically start up.

@pivotal-cla This is an Obvious Fix