### PR TITLE
Disable JPA Open Session In View

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '3.3.2'
+  id 'org.springframework.boot' version '3.3.4'
   id 'io.spring.dependency-management' version '1.1.5'
   id 'org.graalvm.buildtools.native' version '0.10.2'
   id 'org.cyclonedx.bom' version '1.8.2'

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.3</version>
-	<relativePath/>
+    <version>3.3.4</version>
+  <relativePath/>
   </parent>
   <name>petclinic</name>
 
@@ -271,7 +271,7 @@
       <!-- Spring Boot Actuator displays sbom-related information if a CycloneDX SBOM file is
       present at the classpath -->
       <plugin>
-		<?m2e ignore?>
+      <?m2e ignore?>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
       </plugin>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.thymeleaf.mode=HTML
 
 # JPA
 spring.jpa.hibernate.ddl-auto=none
-spring.jpa.open-in-view=true
+spring.jpa.open-in-view=false
 
 # Internationalization
 spring.messages.basename=messages/messages


### PR DESCRIPTION
This PR upgrades to Spring Boot 3.3.4, polishes `pom.xml` to use consistently spaces for indentation, and disable Open JPA Session in View feature as it is not needed anymore.