### PR TITLE
Fix and Refactor: Validate owner ID consistency between form and URL before updating and Refactor logic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -16,7 +16,6 @@
 package org.springframework.samples.petclinic.owner;
 
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -64,9 +63,7 @@ class OwnerController {
 	}
 
 	@GetMapping("/owners/new")
-	public String initCreationForm(Map<String, Object> model) {
-		Owner owner = new Owner();
-		model.put("owner", owner);
+	public String initCreationForm() {
 		return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;
 	}
 
@@ -129,9 +126,7 @@ class OwnerController {
 	}
 
 	@GetMapping("/owners/{ownerId}/edit")
-	public String initUpdateOwnerForm(@PathVariable("ownerId") int ownerId, Model model) {
-		Owner owner = this.owners.findById(ownerId);
-		model.addAttribute(owner);
+	public String initUpdateOwnerForm() {
 		return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;
 	}
 
@@ -141,6 +136,12 @@ class OwnerController {
 		if (result.hasErrors()) {
 			redirectAttributes.addFlashAttribute("error", "There was an error in updating the owner.");
 			return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;
+		}
+
+		if (owner.getId() != ownerId) {
+			result.rejectValue("id", "mismatch", "The owner ID in the form does not match the URL.");
+			redirectAttributes.addFlashAttribute("error", "Owner ID mismatch. Please try again.");
+			return "redirect:/owners/{ownerId}/edit";
 		}
 
 		owner.setId(ownerId);


### PR DESCRIPTION
## Title:
**Enhance: Add validation for owner ID consistency between form and URL, Refactor the process of getting new owner.**

---

## Description:
This PR introduces a validation check to ensure that the `ownerId` from the URL matches the `owner.getId()` in the form submission. And also write a test named `testProcessUpdateOwnerFormWithIdMismatch()` in `OwnerControllerTests` to test this case. This enhancement improves data integrity and prevents potential issues where the form data and URL might be inconsistent, reducing the risk of incorrect data being processed. Delete the useless code to get new `owner`, because  the method `findOwner()` with annotation `@ModelAttribute("owner")` can do the same job ahead.

---

## Problem:
Before this change, it was possible for the `ownerId` in the URL to be different from the `owner.getId()` in the form submission, which could lead to:
- Data inconsistencies
- Potential security risks if a user manually edits the URL and submits data with mismatched ID.

---

## Solution:
- Added a validation check in the `processUpdateOwnerForm` method to compare `owner.getId()` with `ownerId` from the URL.
- If the IDs do not match, an error message is added, and the user is redirected back to the edit page with a flash error message.

---

## Type of Change

Please select the type of change you are making:

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] Refactor create new `owner` process.

---

## Changes:
- Modified the `processUpdateOwnerForm` method to include an ID consistency check.
- Updated the form validation logic to reject the form submission if the IDs do not match.
- Write test method to test the situation that `owner.getId() != owerId`.

## Local Test ScreenShot:
<img width="785" alt="image" src="https://github.com/user-attachments/assets/e7d7d611-b704-4bba-9997-020905dcd497">

## Additional Information:
Maybe for the code to be more readable, it's not a good idea to delete the `@ModuleAttribute` related code. What a trade off🤔. And the `ower.getId()` don't match `ownerId` bug may not happen anymore🥺. But I still try to make it more perfect anyway. Looking forward to your reply, whether good or bad. If there is any mistake in the PR preventing to be merged, plz notify me by comments, ty❤️.

