### PR TITLE
Add Kubernetes support

### DIFF
--- a/k8s/db.yml
+++ b/k8s/db.yml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-db
+type: servicebinding.io/postgresql
+stringData:
+  type: "postgresql"
+  provider: "postgresql"
+  host: "demo-db"
+  port: "5432"
+  database: "petclinic"
+  username: "user"
+  password: "pass"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-db
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: demo-db
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-db
+  labels:
+    app: demo-db
+spec:
+  selector:
+    matchLabels:
+      app: demo-db
+  template:
+    metadata:
+      labels:
+        app: demo-db
+    spec:
+      containers:
+        - image: postgres:17
+          name: postgresql
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: demo-db
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: demo-db
+                  key: password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: demo-db
+                  key: database
+          ports:
+            - containerPort: 5432
+              name: postgresql
+          livenessProbe:
+            tcpSocket:
+              port: postgresql
+          readinessProbe:
+            tcpSocket:
+              port: postgresql
+          startupProbe:
+            tcpSocket:
+              port: postgresql

--- a/k8s/petclinic.yml
+++ b/k8s/petclinic.yml
@@ -1,0 +1,64 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: petclinic
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    app: petclinic
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: petclinic
+  labels:
+    app: petclinic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: petclinic
+  template:
+    metadata:
+      labels:
+        app: petclinic
+    spec:
+      containers:
+        - name: workload
+          image: dsyer/petclinic
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: postgres
+            - name: SERVICE_BINDING_ROOT
+              value: /bindings
+            - name: SPRING_APPLICATION_JSON
+              value: |
+                {
+                  "management.endpoint.health.probes.add-additional-paths": true
+                }
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+          volumeMounts:
+            - mountPath: /bindings/secret
+              name: binding
+              readOnly: true
+      volumes:
+        - name: binding
+          projected:
+            sources:
+              - secret:
+                  name: demo-db


### PR DESCRIPTION
I made some changes that are aimed at adding Kubernetes support to spring-petclinic, for a quick deploy using Kubernetes

I added manifests like `db.yml` and `petclinic.yml`

The first manifest contains the secrets for the database, and the service and deployment. I used Postgresql 17 as the database

The second manifest contains the service and deployment with 1 replica for directly our petclinic. I configured service-bindings, also “liveness” endpoints like `/livez` and `/readyz` were added. The [dsyer/petclinic](https://hub.docker.com/r/dsyer/petclinic) was used as the image

This PR is related to issue #968. Also, I was guided by this [branch](https://github.com/dsyer/spring-petclinic/tree/k8s)