### PR TITLE
Implement K8S deployment testing using Kind in GitHub Actions

### DIFF
--- a/.github/workflows/deploy-and-test-cluster.yml
+++ b/.github/workflows/deploy-and-test-cluster.yml
@@ -1,0 +1,31 @@
+name: Deploy and Test Cluster
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'k8s/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'k8s/**'
+
+jobs:
+  deploy-and-test-cluster:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1
+
+      - name: Deploy application
+        run: |
+          kubectl apply -f k8s/
+
+      - name: Wait for Pods to be ready
+        run: |
+          kubectl wait --for=condition=ready pod -l app=demo-db --timeout=180s
+          kubectl wait --for=condition=ready pod -l app=petclinic --timeout=180s
+


### PR DESCRIPTION
Essentially this PR is a reference to @dsyer [comment](https://github.com/spring-projects/spring-petclinic/pull/1707#issuecomment-2464215589), more specifically the advice to create a separate workflow for K8S deployment

Here I have created a special workflow that deploys the database and our spring-petclinic, and checks if it has successfully deployed or not