### PR TITLE
Add PetValidator unit and integration tests

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
@@ -45,7 +45,6 @@ public interface OwnerRepository extends JpaRepository<Owner, Integer> {
 	 * @return a Collection of {@link PetType}s.
 	 */
 	@Query("SELECT ptype FROM PetType ptype ORDER BY ptype.name")
-	@Transactional(readOnly = true)
 	List<PetType> findPetTypes();
 
 	/**

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.owner;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.Errors;
+import org.springframework.validation.MapBindingResult;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test class for {@link PetValidator}
+ *
+ * @author Wick Dynex
+ */
+@ExtendWith(MockitoExtension.class)
+@DisabledInNativeImage
+public class PetValidatorTests {
+
+	private PetValidator petValidator;
+
+	private Pet pet;
+
+	private PetType petType;
+
+	private Errors errors;
+
+	private static final String petName = "Buddy";
+
+	private static final String petTypeName = "Dog";
+
+	private static final LocalDate petBirthDate = LocalDate.of(1990, 1, 1);
+
+	@BeforeEach
+	void setUp() {
+		petValidator = new PetValidator();
+		pet = new Pet();
+		petType = new PetType();
+		errors = new MapBindingResult(new HashMap<>(), "pet");
+	}
+
+	@Test
+	void testValidate() {
+		petType.setName(petTypeName);
+		pet.setName(petName);
+		pet.setType(petType);
+		pet.setBirthDate(petBirthDate);
+
+		petValidator.validate(pet, errors);
+
+		assertFalse(errors.hasErrors());
+	}
+
+	@Nested
+	class ValidateHasErrors {
+
+		@Test
+		void testValidateWithInvalidPetName() {
+			petType.setName(petTypeName);
+			pet.setName("");
+			pet.setType(petType);
+			pet.setBirthDate(petBirthDate);
+
+			petValidator.validate(pet, errors);
+
+			assertTrue(errors.hasFieldErrors("name"));
+		}
+
+		@Test
+		void testValidateWithInvalidPetType() {
+			pet.setName(petName);
+			pet.setType(null);
+			pet.setBirthDate(petBirthDate);
+
+			petValidator.validate(pet, errors);
+
+			assertTrue(errors.hasFieldErrors("type"));
+		}
+
+		@Test
+		void testValidateWithInvalidBirthDate() {
+			petType.setName(petTypeName);
+			pet.setName(petName);
+			pet.setType(petType);
+			pet.setBirthDate(null);
+
+			petValidator.validate(pet, errors);
+
+			assertTrue(errors.hasFieldErrors("birthDate"));
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Title:
**Add PetValidator unit and integration tests**

---

## Description:
This PR add `PetValidatorTests` to test whether the class `PetValidator` works as expected. Tests including unit and integration tests.

---

## Problem:
The project is lack of a unit test for `PetValidator` class. Without proper testing, the validator’s functionality may go unverified

---

## Solution:
- Add new test: add test file to check each methods of `PetValidate`.

---

## Type of Change

- [X] New feature

---

## Changes:
- Add test class named `PetValidatorTests` to check `PetValidator` work.

---

## Local Test ScreenShot:

<img width="882" alt="image" src="https://github.com/user-attachments/assets/749e8955-0088-4cc2-a51c-6d085edb6087">


---

## Additional Information:

If there are any bad design patterns, design approaches, or bugs in this PR😵‍💫, please point them out, and I will make the necessary changes🥰. 

## Followed Question:

1. Need I update the `Copyright` year at the top of each I've modified files?
2. Need I refactor the `Validate` process, use `Spring Bean Validation` instead of `PetValidation` class?
plz give some idea🤩.