### PR TITLE
Fix the wrong variable name in constructor

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -50,8 +50,8 @@ class OwnerController {
 
 	private final OwnerRepository owners;
 
-	public OwnerController(OwnerRepository clinicService) {
-		this.owners = clinicService;
+	public OwnerController(OwnerRepository owners) {
+		this.owners = owners;
 	}
 
 	@InitBinder

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -37,8 +37,8 @@ class VetController {
 
 	private final VetRepository vetRepository;
 
-	public VetController(VetRepository clinicService) {
-		this.vetRepository = clinicService;
+	public VetController(VetRepository vetRepository) {
+		this.vetRepository = vetRepository;
 	}
 
 	@GetMapping("/vets.html")


### PR DESCRIPTION
## Title:
**Fix the wrong variable name in constructor**

---

## Related Issue
Fixed  #1711 

---

## Description:
This PR fix the bug related to issue  #1711.

---

## Problem:
The variable name is not used and need to be renamed.

---

## Type of Change

- [X] Refactor

---

## Changes:
- Rename variable name in `OwnerController` and `VetController`'s contructor.

---

## Local Test ScreenShot:
<img width="872" alt="image" src="https://github.com/user-attachments/assets/f944dfbd-6583-4388-a6ef-967b3a59dd4a">

