### PR TITLE
Updated the image, text (messages/headings) position of welcome and error page

### DIFF
--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -3,9 +3,13 @@
 <html xmlns:th="https://www.thymeleaf.org" th:replace="~{fragments/layout :: layout (~{::body},'error')}">
 
   <body>
-    <img src="../static/resources/images/pets.png" th:src="@{/resources/images/pets.png}"/>
-    <h2>Something happened...</h2>
-    <p th:text="${message}">Exception message</p>
+    <div class="row">
+      <div class="text-center">
+        <img src="../static/resources/images/pets.png" th:src="@{/resources/images/pets.png}"/>
+        <h2>Something happened...</h2>
+        <p th:text="${message}">Exception message</p>
+      </div>
+    </div>
   </body>
 
 </html>

--- a/src/main/resources/templates/welcome.html
+++ b/src/main/resources/templates/welcome.html
@@ -4,9 +4,13 @@
 
   <body>
 
-    <h2 th:text="#{welcome}">Welcome</h2>
     <div class="row">
-        <div class="col-md-12">
+      <div class="text-center">
+        <h2 th:text="#{welcome}">Welcome</h2>
+      </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12 text-center">
           <img class="img-responsive" src="../static/resources/images/pets.png" th:src="@{/resources/images/pets.png}"/>
         </div>
     </div>


### PR DESCRIPTION
This pull request addresses the positioning of the welcome and error page content, specifically the image and text elements. Previously, the text and images were aligned to the left of the page. In this update, both the image and text elements have been centered to enhance the layout and improve the visual appeal of the welcome and error pages.

### Changes Made:

- Updated the positioning of the welcome message and error page text to be centered on the page.
- Used Bootstrap's text-center class to align the text and image to the center.
- Ensured that the image (located in the pets.png file) is now centrally aligned within the container, maintaining responsiveness.

### Impact:

- The welcome and error page content will now appear in the center of the page, creating a more balanced and visually pleasing layout.
- The change ensures that the content is aligned properly across different screen sizes, improving the user experience.