### PR TITLE
Remove unnecessary @Autowired annotation from the PetTypeFormatter

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/PetTypeFormatter.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetTypeFormatter.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.samples.petclinic.owner;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.Formatter;
 import org.springframework.stereotype.Component;
 
@@ -38,7 +37,6 @@ public class PetTypeFormatter implements Formatter<PetType> {
 
 	private final OwnerRepository owners;
 
-	@Autowired
 	public PetTypeFormatter(OwnerRepository owners) {
 		this.owners = owners;
 	}


### PR DESCRIPTION
I dont't know why but the previous one was not merged: https://github.com/spring-projects/spring-petclinic/pull/1800