### PR TITLE
Remove the unused findAll method from OwnerRepository

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
@@ -69,9 +69,4 @@ public interface OwnerRepository extends JpaRepository<Owner, Integer> {
 	 */
 	Optional<Owner> findById(@Nonnull Integer id);
 
-	/**
-	 * Returns all the owners from data store
-	 **/
-	Page<Owner> findAll(Pageable pageable);
-
 }

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -94,8 +94,6 @@ class OwnerControllerTests {
 		given(this.owners.findByLastNameStartingWith(eq("Franklin"), any(Pageable.class)))
 			.willReturn(new PageImpl<>(List.of(george)));
 
-		given(this.owners.findAll(any(Pageable.class))).willReturn(new PageImpl<>(List.of(george)));
-
 		given(this.owners.findById(TEST_OWNER_ID)).willReturn(Optional.of(george));
 		Visit visit = new Visit();
 		visit.setDate(LocalDate.now());


### PR DESCRIPTION
The `findByLastNameStartingWith` method has replaced the `findAll` one.