### PR TITLE
Fix typo in visits form which causes button to miss its text

### DIFF
--- a/src/main/resources/templates/pets/createOrUpdateVisitForm.html
+++ b/src/main/resources/templates/pets/createOrUpdateVisitForm.html
@@ -36,7 +36,7 @@
     <div class="form-group">
       <div class="col-sm-offset-2 col-sm-10">
         <input type="hidden" name="petId" th:value="${pet.id}" />
-        <button class="btn btn-primary" type="submit" th:text="${addVisit}">Add Visit</button>
+        <button class="btn btn-primary" type="submit" th:text="#{addVisit}">Add Visit</button>
       </div>
     </div>
   </form>


### PR DESCRIPTION
This PR fixes a typo in the text of the submit button of the visits form causing the label of the button to be missing.

#### Validation

Before:

```shell
$ curl -s http://localhost:8080/owners/6/pets/8/visits/new | grep submit
        <button class="btn btn-primary" type="submit"></button>
```

After (note the "Add Visit" text):

```shell
$ curl -s http://localhost:8080/owners/6/pets/8/visits/new | grep submit
        <button class="btn btn-primary" type="submit">Add Visit</button>
```
