### PR TITLE
Add total owner count page using /owners/count endpoint

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -169,5 +169,11 @@ class OwnerController {
 		mav.addObject(owner);
 		return mav;
 	}
+	@GetMapping("/owners/count")
+	public String countOwners(Model model) {
+		int count = owners.countOwners();
+		model.addAttribute("count", count);
+		return "owners/ownerCount"; // we'll create this HTML view next
+	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
@@ -62,4 +62,7 @@ public interface OwnerRepository extends JpaRepository<Owner, Integer> {
 	 */
 	Optional<Owner> findById(@Nonnull Integer id);
 
+	@Query("SELECT COUNT(o) FROM Owner o")
+	int countOwners();
+
 }

--- a/src/main/resources/templates/owners/ownerCount.html
+++ b/src/main/resources/templates/owners/ownerCount.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>Owner Count</title>
+</head>
+<body>
+<h2>Total number of owners: <span th:text="${count}">0</span></h2>
+<a href="/owners">Back to Owners List</a>
+</body>
+</html>
+


### PR DESCRIPTION
- Added `countOwners()` method in `OwnerRepository` using a JPQL query.
- Added `/owners/count` GET endpoint in `OwnerController` to show total owners.
- Created a new Thymeleaf template `ownerCount.html` to display the result.