### PR TITLE
Maven and Gradle version upgrades

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'java'
+  id 'checkstyle'
   id 'org.springframework.boot' version '3.5.0'
   id 'io.spring.dependency-management' version '1.1.7'
   id 'org.graalvm.buildtools.native' version '0.10.6'
@@ -8,17 +9,15 @@ plugins {
   id "io.spring.nohttp" version "0.0.11"
 }
 
-apply plugin: 'java'
-apply plugin: 'checkstyle'
-apply plugin: 'io.spring.javaformat'
-
 gradle.startParameter.excludedTaskNames += [ "checkFormatAot", "checkFormatAotTest" ]
 
 group = 'org.springframework.samples'
 version = '3.5.0'
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_17
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(17)
+  }
 }
 
 repositories {
@@ -85,3 +84,8 @@ checkFormatAotTest.enabled = false
 
 formatAot.enabled = false
 formatAotTest.enabled = false
+
+wrapper {
+  gradleVersion = "8.14.3"
+  distributionType = Wrapper.DistributionType.ALL
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionSha256Sum=ed1a8d686605fd7c23bdf62c7fc7add1c5b23b2bbc3721e661934ef4a4911d7c
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
details:
- Gradle changes: 
  - redundant 'apply' plugin declarations are removed
  -  java 'sourceCompatibility' removed in favor of 'toolchain'
 - Gradle version upgrade: 8.14 -->> 8.14.3
 - Maven version upgrade: 3.9.9 -->> 3.9.10

related links:
- https://docs.gradle.org/8.14.1/release-notes.html
- https://docs.gradle.org/8.14.2/release-notes.html
- https://docs.gradle.org/8.14.3/release-notes.html
- https://maven.apache.org/docs/3.9.10/release-notes.html
- https://committing-crimes.com/articles/2024-10-30-using-gradle-toolchains-properly
- https://docs.gradle.org/8.14.3/userguide/building_java_projects.html#sec:java_cross_compilation