### PR TITLE
docs: Add Demo link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/spring-projects/spring-petclinic) [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=7517918)
 
+# Live Demo: Experience Spring Pet Clinic
+[Click on the link to view live demo](https://spring-framework-petclinic-qctjpkmzuq-od.a.run.app/)
+
 ## Understanding the Spring Petclinic application with a few diagrams
 
 [See the presentation here](https://speakerdeck.com/michaelisvy/spring-petclinic-sample-application)


### PR DESCRIPTION
Added a link to the readme file that redirects to the Spring Pet Clinic demo. The intention is for the user to preview the application before downloading or running via Gitpot or Codespaces.  The link to the demo is obtained from the official Spring pet clinic site: https://spring-petclinic.github.io/