### PR TITLE
Add OpenAPI docs and monitoring with Prometheus and Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,13 @@ For additional details, please refer to the blog post [Hello DCO, Goodbye CLA: S
 ## License
 
 The Spring PetClinic sample application is released under version 2.0 of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0).
+
+## Using Docker Compose for Local Development
+
+If you prefer using Docker for local development, a `docker-compose.dev.yml` file has been provided. This spins up a PostgreSQL database, Prometheus, Grafana and the PetClinic application preconfigured.
+
+```bash
+docker compose -f docker-compose.dev.yml up
+```
+
+Once started, access the application at <http://localhost:8080/>. The API documentation is available via Swagger UI at <http://localhost:8080/swagger-ui.html>. Prometheus metrics are exposed at <http://localhost:8080/actuator/prometheus> and Grafana dashboards are available at <http://localhost:3000/>.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,28 @@
+version: "3.8"
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: petclinic
+      POSTGRES_USER: petclinic
+      POSTGRES_PASSWORD: petclinic
+    ports:
+      - "5432:5432"
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+  petclinic:
+    build: .
+    environment:
+      SPRING_PROFILES_ACTIVE: postgres
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,12 @@
 
   <build>
     <plugins>
+     <!-- API documentation -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <ar>tifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.6.0</version>
+        </dependency>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/src/main/java/org/springframework/samples/petclinic/config/OpenApiConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/config/OpenApiConfig.java
@@ -1,0 +1,10 @@
+package org.springframework.samples.petclinic.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "Pet Clinic API", version = "1.0", description = "Documentation for Pet Clinic API"))
+public class OpenApiConfig {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,10 +14,10 @@ spring.jpa.open-in-view=false
 spring.messages.basename=messages/messages
 
 # Actuator
-management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
 
 # Logging
-logging.level.org.springframework=INFO
+logging.level.org.springframework=INO
 # logging.level.org.springframework.web=DEBUG
 # logging.level.org.springframework.context.annotation=TRACE
 


### PR DESCRIPTION
This pull request introduces OpenAPI/Swagger documentation to the PetClinic application using springdoc-openapi, adds a configuration class, and updates the build accordingly. It also exposes Prometheus metrics via the Spring Boot actuator and adds a docker-compose.dev.yml file to spin up Postgres, Prometheus, Grafana, and the PetClinic service for local development. The README has been updated with quick start instructions and endpoints for Swagger UI, Prometheus, and Grafana.