### PR TITLE
Fix test port conflicts by adding dynamic port configuration

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationTests.java
@@ -29,9 +29,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.samples.petclinic.vet.VetRepository;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.RestTemplate;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
 public class PetClinicIntegrationTests {
 
 	@LocalServerPort

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,17 @@
+# Test configuration - Use random available port
+server.port=0
+
+# Database configuration for tests
+database=h2
+spring.sql.init.schema-locations=classpath*:db/${database}/schema.sql
+spring.sql.init.data-locations=classpath*:db/${database}/data.sql
+
+# JPA configuration for tests
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+
+# Disable caching during tests
+spring.web.resources.cache.cachecontrol.max-age=0
+
+# Test logging
+logging.level.org.springframework.samples.petclinic=DEBUG


### PR DESCRIPTION
Fixes #1961

Problem:
- Integration tests fail when port 8080 is already in use
- Tests cannot start embedded server due to port conflicts
- This prevents reliable test execution in CI/CD environments

Solution:
- Add application-test.properties with server.port=0 for random port assignment
- Configure PetClinicIntegrationTests to use test profile with @ActiveProfiles('test')
- Tests now automatically use available ports and never conflict

Changes:
- Create src/test/resources/application-test.properties with test-specific configuration
- Add @ActiveProfiles('test') annotation to PetClinicIntegrationTests.java
- Configure separate database, caching, and logging settings for tests

Testing:
- Integration tests now run successfully with random ports (e.g., 60479)
- No more port conflicts during test execution
- Tests are isolated from main application configuration

See: https://github.com/spring-projects/spring-petclinic/issues/1961

Signed-off-by: Farhan Shahid <farhan7479@users.noreply.github.com>