### PR TITLE
Add OwnerRestController for REST API endpoints

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/rest/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/OwnerRestController.java
@@ -1,0 +1,51 @@
+package org.springframework.samples.petclinic.rest;
+
+import java.util.List;
+
+import org.springframework.samples.petclinic.owner.Owner;
+import org.springframework.samples.petclinic.owner.OwnerRepository;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/owners")
+public class OwnerRestController {
+
+    private final OwnerRepository ownerRepository;
+
+    public OwnerRestController(OwnerRepository ownerRepository) {
+        this.ownerRepository = ownerRepository;
+    }
+
+    @GetMapping
+    public List<Owner> getAllOwners() {
+        return ownerRepository.findAll();
+    }
+
+    @GetMapping("/{ownerId}")
+    public Owner getOwnerById(@PathVariable int ownerId) {
+        return ownerRepository.findById(ownerId)
+                .orElseThrow(() -> new IllegalArgumentException("Owner not found with id " + ownerId));
+    }
+
+    @PostMapping
+    public Owner createOwner(@RequestBody Owner owner) {
+        return ownerRepository.save(owner);
+    }
+
+    @PutMapping("/{ownerId}")
+    public Owner updateOwner(@PathVariable int ownerId, @RequestBody Owner ownerRequest) {
+        return ownerRepository.findById(ownerId).map(owner -> {
+            owner.setFirstName(ownerRequest.getFirstName());
+            owner.setLastName(ownerRequest.getLastName());
+            owner.setAddress(ownerRequest.getAddress());
+            owner.setCity(ownerRequest.getCity());
+            owner.setTelephone(ownerRequest.getTelephone());
+            return ownerRepository.save(owner);
+        }).orElseThrow(() -> new IllegalArgumentException("Owner not found with id " + ownerId));
+    }
+
+    @DeleteMapping("/{ownerId}")
+    public void deleteOwner(@PathVariable int ownerId) {
+        ownerRepository.deleteById(ownerId);
+    }
+}


### PR DESCRIPTION
This commit introduces a new REST API layer for the Owner entity.

- Created OwnerRestController.java under the new package `rest`.
- Provides endpoints for CRUD operations on owners: GET /api/owners GET /api/owners/{ownerId} POST /api/owners PUT /api/owners/{ownerId} DELETE /api/owners/{ownerId}
- Keeps existing Thymeleaf-based OwnerController intact.
- Enables external clients to access Owner data as JSON without breaking the web UI.

This addition improves the flexibility of the PetClinic application by supporting both web UI and REST API clients.