### PR TITLE
docs: capitalize 'JAR' in README for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Run Petclinic locally
 
-Spring Petclinic is a [Spring Boot](https://spring.io/guides/gs/spring-boot) application built using [Maven](https://spring.io/guides/gs/maven/) or [Gradle](https://spring.io/guides/gs/gradle/). You can build a jar file and run it from the command line (it should work just as well with Java 17 or newer):
+Spring Petclinic is a [Spring Boot](https://spring.io/guides/gs/spring-boot) application built using [Maven](https://spring.io/guides/gs/maven/) or [Gradle](https://spring.io/guides/gs/gradle/). You can build a JAR file and run it from the command line (it should work just as well with Java 17 or newer):
 
 ```bash
 git clone https://github.com/spring-projects/spring-petclinic.git


### PR DESCRIPTION
This PR updates the README to use the uppercase form "JAR" instead of "jar" for consistency with Java terminology (Java ARchive). 

- Change: "You can build a jar file and run it from the command line:" -> "You can build a JAR file and run it from the command line:"
- No code changes, documentation-only update.

Thanks for maintaining this project — small docs fix to improve consistency.