### PR TITLE
fix: update MySQL user creation for MySQL 8.0+ compatibility

### DIFF
--- a/src/main/resources/db/mysql/user.sql
+++ b/src/main/resources/db/mysql/user.sql
@@ -4,4 +4,8 @@ ALTER DATABASE petclinic
   DEFAULT CHARACTER SET utf8
   DEFAULT COLLATE utf8_general_ci;
 
-GRANT ALL PRIVILEGES ON petclinic.* TO 'petclinic'@'%' IDENTIFIED BY 'petclinic';
+CREATE USER IF NOT EXISTS 'petclinic'@'%' IDENTIFIED BY 'petclinic';
+
+GRANT ALL PRIVILEGES ON petclinic.* TO 'petclinic'@'%';
+
+FLUSH PRIVILEGES;


### PR DESCRIPTION
## Description

Fixes MySQL user creation script to be compatible with MySQL 8.0+.

## Problem

The current `user.sql` uses deprecated syntax that fails on MySQL 8.0+:
```sql
GRANT ALL PRIVILEGES ON petclinic.* TO 'petclinic'@'%' IDENTIFIED BY 'petclinic';
```

Error message:
```
ERROR 1064 (42000): You have an error in your SQL syntax; 
check the manual that corresponds to your MySQL server version 
for the right syntax to use near 'IDENTIFIED BY 'petclinic'' at line 1
```

## Solution

Updated to MySQL 8.0+ standard syntax following [official documentation](https://dev.mysql.com/doc/refman/8.0/en/grant.html):

Fixes #2112