### PR TITLE
Add /api/version endpoint to show app version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -446,4 +446,12 @@
       </build>
     </profile>
   </profiles>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
 </project>

--- a/src/main/java/org/springframework/samples/petclinic/system/VersionController.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/VersionController.java
@@ -1,0 +1,20 @@
+package org.springframework.samples.petclinic.system;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.Map;
+
+@RestController
+public class VersionController {
+
+	@Value("${app.version:unknown}")
+	private String version ="unknown";
+
+	@GetMapping("/api/version")
+	public Map<String, String> version() {
+		return Map.of("version", version);
+	}
+}
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,4 @@ logging.level.org.springframework=INFO
 
 # Maximum time static resources should be cached
 spring.web.resources.cache.cachecontrol.max-age=12h
+app.version=@project.version@


### PR DESCRIPTION
### Summary
Added a new REST endpoint `/api/version` that returns the current application version defined in `pom.xml`.

### Implementation Details
- Created a new class `VersionController` in `org.springframework.samples.petclinic.system`.
- Added the `app.version` property to `application.properties`.
- Updated `pom.xml` to enable Maven resource filtering.

### Verification
- The project builds successfully with `mvn clean package`.
- Running `http://localhost:8080/api/version` returns:
  {
    "version": "4.0.0-SNAPSHOT"
  }
