### PR TITLE
Refactor: Fix code smells detected by PMD analysis

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/PetClinicApplication.java
+++ b/src/main/java/org/springframework/samples/petclinic/PetClinicApplication.java
@@ -29,6 +29,10 @@ import org.springframework.context.annotation.ImportRuntimeHints;
 @ImportRuntimeHints(PetClinicRuntimeHints.class)
 public class PetClinicApplication {
 
+	private PetClinicApplication() {
+		// prevent instantiation
+	}
+
 	public static void main(String[] args) {
 		SpringApplication.run(PetClinicApplication.class, args);
 	}

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -107,8 +107,9 @@ class PetController {
 	public String processCreationForm(Owner owner, @Valid Pet pet, BindingResult result,
 			RedirectAttributes redirectAttributes) {
 
-		if (StringUtils.hasText(pet.getName()) && pet.isNew() && owner.getPet(pet.getName(), true) != null)
+		if (StringUtils.hasText(pet.getName()) && pet.isNew() && owner.getPet(pet.getName(), true) != null) {
 			result.rejectValue("name", "duplicate", "already exists");
+		}
 
 		LocalDate currentDate = LocalDate.now();
 		if (pet.getBirthDate() != null && pet.getBirthDate().isAfter(currentDate)) {

--- a/src/test/java/org/springframework/samples/petclinic/MysqlTestApplication.java
+++ b/src/test/java/org/springframework/samples/petclinic/MysqlTestApplication.java
@@ -32,11 +32,15 @@ import org.testcontainers.utility.DockerImageName;
 @Configuration
 public class MysqlTestApplication {
 
+	private MysqlTestApplication() {
+		// prevent instantiation
+	}
+
 	@ServiceConnection
 	@Profile("mysql")
 	@Bean
-	static MySQLContainer container() {
-		return new MySQLContainer(DockerImageName.parse("mysql:9.5"));
+	static MySQLContainer<?> container() {
+		return new MySQLContainer<>(DockerImageName.parse("mysql:9.5"));
 	}
 
 	public static void main(String[] args) {

--- a/src/test/java/org/springframework/samples/petclinic/PostgresIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PostgresIntegrationTests.java
@@ -110,7 +110,10 @@ public class PostgresIntegrationTests {
 
 		public void printProperties() {
 			for (EnumerablePropertySource<?> source : findPropertiesPropertySources()) {
-				log.info("PropertySource: " + source.getName());
+				if (log.isInfoEnabled()) {
+					log.info("PropertySource: " + source.getName());
+				}
+
 				String[] names = source.getPropertyNames();
 				Arrays.sort(names);
 				for (String name : names) {
@@ -125,11 +128,14 @@ public class PostgresIntegrationTests {
 					assertNotNull(sourceProperty.toString(), "source property toString() returned null.");
 
 					String value = sourceProperty.toString();
-					if (resolved.equals(value)) {
-						log.info(name + "=" + resolved);
-					}
-					else {
-						log.info(name + "=" + value + " OVERRIDDEN to " + resolved);
+
+					if (log.isInfoEnabled()) {
+						if (resolved.equals(value)) {
+							log.info(name + "=" + resolved);
+						}
+						else {
+							log.info(name + "=" + value + " OVERRIDDEN to " + resolved);
+						}
 					}
 				}
 			}

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
@@ -81,16 +81,15 @@ class PetTypeFormatterTests {
 	 */
 	private List<PetType> makePetTypes() {
 		List<PetType> petTypes = new ArrayList<>();
-		petTypes.add(new PetType() {
-			{
-				setName("Dog");
-			}
-		});
-		petTypes.add(new PetType() {
-			{
-				setName("Bird");
-			}
-		});
+
+		PetType dog = new PetType();
+		dog.setName("Dog");
+		petTypes.add(dog);
+
+		PetType bird = new PetType();
+		bird.setName("Bird");
+		petTypes.add(bird);
+
 		return petTypes;
 	}
 

--- a/src/test/java/org/springframework/samples/petclinic/system/I18nPropertiesSyncTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/I18nPropertiesSyncTest.java
@@ -56,8 +56,9 @@ public class I18nPropertiesSyncTest {
 				String line = lines.get(i).trim();
 
 				if (line.startsWith("//") || line.startsWith("@") || line.contains("log.")
-						|| line.contains("System.out"))
+						|| line.contains("System.out")) {
 					continue;
+				}
 
 				if (file.toString().endsWith(".html")) {
 					boolean hasLiteralText = HTML_TEXT_LITERAL.matcher(line).find();
@@ -115,8 +116,9 @@ public class I18nPropertiesSyncTest {
 			String fileName = entry.getKey();
 			// We use fallback logic to include english strings, hence messages_en is not
 			// populated.
-			if (fileName.equals(baseFile) || fileName.equals("messages_en.properties"))
+			if (fileName.equals(baseFile) || fileName.equals("messages_en.properties")) {
 				continue;
+			}
 
 			Properties props = entry.getValue();
 			Set<String> missingKeys = new TreeSet<>(baseKeys);


### PR DESCRIPTION
Hello! I ran a PMD analysis on the project and spotted a few code smells that could be cleaned up.

I've fixed 4 specific patterns to improve code consistency and performance:

* **Control Statement Braces:** Added missing braces to `if/else` blocks (e.g., in `PetController.java`) to prevent scope errors.
* **Guard Log Statement:** Wrapped logger calls with `isInfoEnabled()` checks to avoid unnecessary string processing.
* **Double Brace Initialization:** Replaced double-brace init with standard collection creation to avoid anonymous classes overhead.
* **Use Utility Class:** Added private constructors to utility classes to prevent instantiation.

I hope these contributions are helpful to the project. Thank you!