### PR TITLE
Tests: Add null check test case to PetTypeFormatterTests

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetTypeFormatterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -58,6 +58,13 @@ class PetTypeFormatterTests {
 		petType.setName("Hamster");
 		String petTypeName = this.petTypeFormatter.print(petType, Locale.ENGLISH);
 		assertThat(petTypeName).isEqualTo("Hamster");
+	}
+
+	@Test
+	void testPrintWithNullName() {
+		PetType petType = new PetType();
+		String petTypeName = this.petTypeFormatter.print(petType, Locale.ENGLISH);
+		assertThat(petTypeName).isEqualTo("<null>");
 	}
 
 	@Test


### PR DESCRIPTION
## Description
This PR improves the test coverage for the `PetTypeFormatter` class by adding a test case for handling `PetType` objects with null names.

## Changes
- Modified `PetTypeFormatterTests.java` to include `testPrintWithNullName`.
- Verifies that the formatter correctly returns `"<null>"` when the pet name is missing, rather than throwing a NullPointerException or returning an unexpected value.

## Context
While reviewing the `PetTypeFormatter`, I noticed that the behavior for printing a `PetType` with a null name was not explicitly tested. This ensures the formatter handles data anomalies gracefully.

## Checklist
- [x] Code compiles correctly
- [x] Created/updated tests
- [x] All tests passing locally
- [x] Overall Tests Branch and Line Coverage Improved 