### PR TITLE
Fix: Add validation to prevent creating a pet with an empty name

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -105,6 +105,11 @@ class PetController {
 	@PostMapping("/pets/new")
 	public String processCreationForm(Owner owner, @Valid Pet pet, BindingResult result,
 			RedirectAttributes redirectAttributes) {
+		// Validate empty name
+		if (!StringUtils.hasText(pet.getName())) {
+			result.rejectValue("name", "required", "Pet name must not be empty");
+			return VIEWS_PETS_CREATE_OR_UPDATE_FORM;
+		}
 
 		if (StringUtils.hasText(pet.getName()) && pet.isNew() && owner.getPet(pet.getName(), true) != null)
 			result.rejectValue("name", "duplicate", "already exists");


### PR DESCRIPTION
This PR adds a server-side validation check in PetController to prevent creating a Pet with an empty name.

- Prevents invalid pet entries
- Provides clear error message to users
- Ensures consistent validation with the update form