### PR TITLE
Set JaCoCo plugin configuration for coverage reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,10 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>${jacoco.version}</version>
+        <configuration>
+          <destFile>${basedir}/target/coverage-reports/jacoco-unit.exec</destFile>
+          <dataFile>${basedir}/target/coverage-reports/jacoco-unit.exec</dataFile>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Configure JaCoCo plugin to specify destination and data files for coverage reports.