### PR TITLE
Use snake case physical naming strategy

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
@@ -30,7 +30,7 @@ import jakarta.validation.constraints.NotBlank;
 @MappedSuperclass
 public class NamedEntity extends BaseEntity {
 
-	@Column(name = "name")
+	@Column
 	@NotBlank
 	private String name;
 

--- a/src/main/java/org/springframework/samples/petclinic/model/Person.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Person.java
@@ -27,11 +27,11 @@ import jakarta.validation.constraints.NotBlank;
 @MappedSuperclass
 public class Person extends BaseEntity {
 
-	@Column(name = "first_name")
+	@Column
 	@NotBlank
 	private String firstName;
 
-	@Column(name = "last_name")
+	@Column
 	@NotBlank
 	private String lastName;
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -48,15 +48,15 @@ import jakarta.validation.constraints.NotBlank;
 @Table(name = "owners")
 public class Owner extends Person {
 
-	@Column(name = "address")
+	@Column
 	@NotBlank
 	private String address;
 
-	@Column(name = "city")
+	@Column
 	@NotBlank
 	private String city;
 
-	@Column(name = "telephone")
+	@Column
 	@NotBlank
 	@Pattern(regexp = "\\d{10}", message = "{telephone.invalid}")
 	private String telephone;

--- a/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
@@ -45,7 +45,7 @@ import jakarta.persistence.Table;
 @Table(name = "pets")
 public class Pet extends NamedEntity {
 
-	@Column(name = "birth_date")
+	@Column
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
 	private LocalDate birthDate;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,7 @@ spring.thymeleaf.mode=HTML
 # JPA
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.open-in-view=false
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategySnakeCaseImpl
 
 # Internationalization
 spring.messages.basename=messages/messages


### PR DESCRIPTION
Use snake case physical naming strategy to reduce the need to specify column names.

`org.hibernate.boot.model.naming.PhysicalNamingStrategySnakeCaseImpl` replaces the deprecated `org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy`