### PR TITLE
Add validation to Owner telephone field

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -82,6 +82,9 @@ public class Owner extends Person {
 		this.city = city;
 	}
 
+	@NotBlank
+	@Pattern(regexp = "\\d{10}", message = "Telephone must be a 10-digit number")
+	@Column(name = "telephone")
 	public String getTelephone() {
 		return this.telephone;
 	}


### PR DESCRIPTION
This PR adds validation to the Owner.telephone field to ensure it is not blank
and contains a valid 10-digit number. This improves data integrity and user input validation.
