### PR TITLE
Use LAZY fetch type for Owner pets relationship

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -33,7 +33,7 @@ import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.NotBlank;
-
+import jakarta.persistence.FetchType;
 /**
  * Simple JavaBean domain object representing an owner.
  *
@@ -61,7 +61,7 @@ public class Owner extends Person {
 	@Pattern(regexp = "\\d{10}", message = "{telephone.invalid}")
 	private String telephone;
 
-	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	@JoinColumn(name = "owner_id")
 	@OrderBy("name")
 	private final List<Pet> pets = new ArrayList<>();


### PR DESCRIPTION
Updated Owner entity to use FetchType.LAZY instead of EAGER for pets relationship to avoid unnecessary eager loading.
Fixes spring-projects/spring-petclinic#2157
