### PR TITLE
Fix #2203: Display owner ID, pet count, and allow owner deletion

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Person.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Person.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.samples.petclinic.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 
 /**
@@ -27,6 +26,10 @@ import jakarta.validation.constraints.NotBlank;
 @MappedSuperclass
 public class Person extends BaseEntity {
 
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
 	@Column
 	@NotBlank
 	private String firstName;
@@ -34,6 +37,10 @@ public class Person extends BaseEntity {
 	@Column
 	@NotBlank
 	private String lastName;
+
+	public Integer getId() {
+		return id;
+	}
 
 	public String getFirstName() {
 		return this.firstName;

--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -19,18 +19,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import jakarta.persistence.*;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.samples.petclinic.model.Person;
 import org.springframework.util.Assert;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.NotBlank;
 
@@ -65,6 +58,11 @@ public class Owner extends Person {
 	@JoinColumn(name = "owner_id")
 	@OrderBy("name")
 	private final List<Pet> pets = new ArrayList<>();
+
+	@Transient
+	public int getPetCount() {
+		return pets == null ? 0 : pets.size();
+	}
 
 	public String getAddress() {
 		return this.address;

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -173,4 +173,37 @@ class OwnerController {
 		return mav;
 	}
 
+	/**
+	 * Deletes an owner if and only if the owner has no pets.
+	 * <p>
+	 * If the owner still has pets associated, the deletion is blocked and
+	 * an error message is shown to the user.
+	 *
+	 * @param ownerId the ID of the owner to be deleted
+	 * @param redirectAttributes used to pass success or error messages after redirect
+	 * @return a redirect to the owners list page or back to the owner details page
+	 */
+	@PostMapping("/owners/{ownerId}/delete")
+	public String deleteOwner(
+		@PathVariable("ownerId") int ownerId,
+		RedirectAttributes redirectAttributes) {
+
+		Owner owner = owners.findById(ownerId)
+			.orElseThrow(() -> new IllegalArgumentException(
+				"Owner not found with id: " + ownerId));
+
+		if (owner.getPetCount() > 0) {
+			redirectAttributes.addFlashAttribute(
+				"error", "Owner cannot be deleted while pets exist.");
+			return "redirect:/owners/" + ownerId;
+		}
+
+		owners.delete(owner);
+		redirectAttributes.addFlashAttribute(
+			"message", "Owner deleted successfully.");
+
+		return "redirect:/owners";
+	}
+
+
 }

--- a/src/main/resources/templates/owners/ownerDetails.html
+++ b/src/main/resources/templates/owners/ownerDetails.html
@@ -31,13 +31,25 @@
       <th th:text="#{telephone}">Telephone</th>
       <td th:text="*{telephone}"></td>
     </tr>
+    <tr>
+      <th>Number of Pets</th>
+      <td th:text="*{petCount}"></td>
+    </tr>
   </table>
 
   <a th:href="@{__${owner.id}__/edit}" class="btn btn-primary" th:text="#{editOwner}">Edit
     Owner</a>
   <a th:href="@{__${owner.id}__/pets/new}" class="btn btn-primary" th:text="#{addNewPet}">Add
     New Pet</a>
-
+  <form th:action="@{__${owner.id}__/delete}"
+        method="post"
+        style="display:inline">
+    <a href="#"
+       onclick="if(confirm('Are you sure you want to delete this owner?')) this.closest('form').submit(); return false;"
+       th:style="${owner.petCount > 0} ? 'pointer-events:none;color:gray;' : ''">
+      Delete Owner
+    </a>
+  </form>
   <br />
   <br />
   <br />


### PR DESCRIPTION
Fixes #2203

- Display owner ID on the owner details page
- Display number of pets for an owner
- Allow deleting an owner only when no pets are associated