### PR TITLE
Add /healthz and validate owner last name

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Person.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Person.java
@@ -32,7 +32,7 @@ public class Person extends BaseEntity {
 	private String firstName;
 
 	@Column
-	@NotBlank
+	@NotBlank(message = "Last name is required")
 	private String lastName;
 
 	public String getFirstName() {

--- a/src/main/java/org/springframework/samples/petclinic/system/HealthController.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/HealthController.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.system;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class HealthController {
+
+	@GetMapping("/healthz")
+	String healthz() {
+		return "ok";
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -33,6 +33,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
@@ -121,6 +122,20 @@ class OwnerControllerTests {
 	}
 
 	@Test
+	void testProcessCreationFormEmptyLastName() throws Exception {
+		mockMvc
+			.perform(post("/owners/new").param("firstName", "Joe")
+					.param("lastName", "")
+					.param("address", "123 Caramel Street")
+					.param("city", "London")
+					.param("telephone", "1234567890"))
+			.andExpect(status().isOk())
+			.andExpect(model().attributeHasFieldErrors("owner", "lastName"))
+			.andExpect(content().string(containsString("Last name is required")))
+			.andExpect(view().name("owners/createOrUpdateOwnerForm"));
+	}
+
+	@Test
 	void testProcessCreationFormHasErrors() throws Exception {
 		mockMvc
 			.perform(post("/owners/new").param("firstName", "Joe").param("lastName", "Bloggs").param("city", "London"))
@@ -197,6 +212,20 @@ class OwnerControllerTests {
 		mockMvc.perform(post("/owners/{ownerId}/edit", TEST_OWNER_ID))
 			.andExpect(status().is3xxRedirection())
 			.andExpect(view().name("redirect:/owners/{ownerId}"));
+	}
+
+	@Test
+	void testProcessUpdateOwnerFormEmptyLastName() throws Exception {
+		mockMvc
+			.perform(post("/owners/{ownerId}/edit", TEST_OWNER_ID).param("firstName", "Joe")
+					.param("lastName", "")
+					.param("address", "123 Caramel Street")
+					.param("city", "London")
+					.param("telephone", "1234567890"))
+			.andExpect(status().isOk())
+			.andExpect(model().attributeHasFieldErrors("owner", "lastName"))
+			.andExpect(content().string(containsString("Last name is required")))
+			.andExpect(view().name("owners/createOrUpdateOwnerForm"));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/samples/petclinic/system/HealthControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/HealthControllerTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.system;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.aot.DisabledInAotMode;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(HealthController.class)
+@DisabledInNativeImage
+@DisabledInAotMode
+class HealthControllerTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void testHealthz() throws Exception {
+		mockMvc.perform(get("/healthz")).andExpect(status().isOk()).andExpect(content().string("ok"));
+	}
+
+}


### PR DESCRIPTION
## Summary
- add /healthz endpoint with MockMvc coverage
- enforce non-blank owner lastName with clear validation message
- add tests for create/update validation cases

## Test plan
- not run (Java tooling not installed on server)