### PR TITLE
Fix #2157: Optimize Entity Relationships with LAZY Fetching and BatchSize

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.samples.petclinic.owner;
 
+import org.hibernate.annotations.BatchSize;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -61,9 +63,10 @@ public class Owner extends Person {
 	@Pattern(regexp = "\\d{10}", message = "{telephone.invalid}")
 	private String telephone;
 
-	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	@JoinColumn(name = "owner_id")
 	@OrderBy("name")
+	@BatchSize(size = 10)
 	private final List<Pet> pets = new ArrayList<>();
 
 	public String getAddress() {
@@ -102,8 +105,10 @@ public class Owner extends Person {
 
 	/**
 	 * Return the Pet with the given name, or null if none found for this Owner.
+	 * 
 	 * @param name to test
-	 * @return the Pet with the given name, or null if no such Pet exists for this Owner
+	 * @return the Pet with the given name, or null if no such Pet exists for this
+	 *         Owner
 	 */
 	public Pet getPet(String name) {
 		return getPet(name, false);
@@ -111,8 +116,10 @@ public class Owner extends Person {
 
 	/**
 	 * Return the Pet with the given id, or null if none found for this Owner.
+	 * 
 	 * @param id to test
-	 * @return the Pet with the given id, or null if no such Pet exists for this Owner
+	 * @return the Pet with the given id, or null if no such Pet exists for this
+	 *         Owner
 	 */
 	public Pet getPet(Integer id) {
 		for (Pet pet : getPets()) {
@@ -128,9 +135,11 @@ public class Owner extends Person {
 
 	/**
 	 * Return the Pet with the given name, or null if none found for this Owner.
-	 * @param name to test
+	 * 
+	 * @param name      to test
 	 * @param ignoreNew whether to ignore new pets (pets that are not saved yet)
-	 * @return the Pet with the given name, or null if no such Pet exists for this Owner
+	 * @return the Pet with the given name, or null if no such Pet exists for this
+	 *         Owner
 	 */
 	public Pet getPet(String name, boolean ignoreNew) {
 		for (Pet pet : getPets()) {
@@ -147,17 +156,18 @@ public class Owner extends Person {
 	@Override
 	public String toString() {
 		return new ToStringCreator(this).append("id", this.getId())
-			.append("new", this.isNew())
-			.append("lastName", this.getLastName())
-			.append("firstName", this.getFirstName())
-			.append("address", this.address)
-			.append("city", this.city)
-			.append("telephone", this.telephone)
-			.toString();
+				.append("new", this.isNew())
+				.append("lastName", this.getLastName())
+				.append("firstName", this.getFirstName())
+				.append("address", this.address)
+				.append("city", this.city)
+				.append("telephone", this.telephone)
+				.toString();
 	}
 
 	/**
 	 * Adds the given {@link Visit} to the {@link Pet} with the given identifier.
+	 * 
 	 * @param petId the identifier of the {@link Pet}, must not be {@literal null}.
 	 * @param visit the visit to add, must not be {@literal null}.
 	 */

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -37,6 +37,7 @@ import org.springframework.web.servlet.ModelAndView;
 import jakarta.validation.Valid;
 
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Juergen Hoeller
@@ -65,8 +66,8 @@ class OwnerController {
 	public Owner findOwner(@PathVariable(name = "ownerId", required = false) Integer ownerId) {
 		return ownerId == null ? new Owner()
 				: this.owners.findById(ownerId)
-					.orElseThrow(() -> new IllegalArgumentException("Owner not found with id: " + ownerId
-							+ ". Please ensure the ID is correct " + "and the owner exists in the database."));
+						.orElseThrow(() -> new IllegalArgumentException("Owner not found with id: " + ownerId
+								+ ". Please ensure the ID is correct " + "and the owner exists in the database."));
 	}
 
 	@GetMapping("/owners/new")
@@ -92,6 +93,7 @@ class OwnerController {
 	}
 
 	@GetMapping("/owners")
+	@Transactional(readOnly = true)
 	public String processFindForm(@RequestParam(defaultValue = "1") int page, Owner owner, BindingResult result,
 			Model model) {
 		// allow parameterless GET request for /owners to return all records
@@ -115,6 +117,9 @@ class OwnerController {
 		}
 
 		// multiple owners found
+		// Initialize pets for the list view
+		ownersResults.forEach(o -> o.getPets().size());
+
 		return addPaginationModel(page, model, ownersResults);
 	}
 
@@ -160,15 +165,24 @@ class OwnerController {
 
 	/**
 	 * Custom handler for displaying an owner.
+	 * 
 	 * @param ownerId the ID of the owner to display
 	 * @return a ModelMap with the model attributes for the view
 	 */
 	@GetMapping("/owners/{ownerId}")
+	@Transactional(readOnly = true)
 	public ModelAndView showOwner(@PathVariable("ownerId") int ownerId) {
 		ModelAndView mav = new ModelAndView("owners/ownerDetails");
 		Optional<Owner> optionalOwner = this.owners.findById(ownerId);
 		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
 				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
+		// Initialize lazy collections
+		owner.getPets().forEach(pet -> {
+			pet.getVisits().size();
+			if (pet.getType() != null) {
+				pet.getType().getName();
+			}
+		});
 		mav.addObject(owner);
 		return mav;
 	}

--- a/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.samples.petclinic.owner;
 
+import org.hibernate.annotations.BatchSize;
+
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -49,13 +51,14 @@ public class Pet extends NamedEntity {
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
 	private LocalDate birthDate;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "type_id")
 	private PetType type;
 
-	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	@JoinColumn(name = "pet_id")
 	@OrderBy("date ASC")
+	@BatchSize(size = 10)
 	private final Set<Visit> visits = new LinkedHashSet<>();
 
 	public void setBirthDate(LocalDate birthDate) {

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -36,6 +36,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import jakarta.validation.Valid;
 
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Juergen Hoeller
@@ -64,14 +65,17 @@ class PetController {
 	}
 
 	@ModelAttribute("owner")
+	@Transactional(readOnly = true)
 	public Owner findOwner(@PathVariable("ownerId") int ownerId) {
 		Optional<Owner> optionalOwner = this.owners.findById(ownerId);
 		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
 				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
+		owner.getPets().size();
 		return owner;
 	}
 
 	@ModelAttribute("pet")
+	@Transactional(readOnly = true)
 	public Pet findPet(@PathVariable("ownerId") int ownerId,
 			@PathVariable(name = "petId", required = false) Integer petId) {
 
@@ -159,8 +163,9 @@ class PetController {
 
 	/**
 	 * Updates the pet details if it exists or adds a new pet to the owner.
+	 * 
 	 * @param owner The owner of the pet
-	 * @param pet The pet with updated details
+	 * @param pet   The pet with updated details
 	 */
 	private void updatePetDetails(Owner owner, Pet pet) {
 		Integer id = pet.getId();
@@ -171,8 +176,7 @@ class PetController {
 			existingPet.setName(pet.getName());
 			existingPet.setBirthDate(pet.getBirthDate());
 			existingPet.setType(pet.getType());
-		}
-		else {
+		} else {
 			owner.addPet(pet);
 		}
 		this.owners.save(owner);

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 
 import jakarta.validation.Valid;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Juergen Hoeller
@@ -53,13 +54,17 @@ class VisitController {
 	}
 
 	/**
-	 * Called before each and every @RequestMapping annotated method. 2 goals: - Make sure
-	 * we always have fresh data - Since we do not use the session scope, make sure that
+	 * Called before each and every @RequestMapping annotated method. 2 goals: -
+	 * Make sure
+	 * we always have fresh data - Since we do not use the session scope, make sure
+	 * that
 	 * Pet object always has an id (Even though id is not part of the form fields)
+	 * 
 	 * @param petId
 	 * @return Pet
 	 */
 	@ModelAttribute("visit")
+	@Transactional(readOnly = true)
 	public Visit loadPetWithVisit(@PathVariable("ownerId") int ownerId, @PathVariable("petId") int petId,
 			Map<String, Object> model) {
 		Optional<Owner> optionalOwner = owners.findById(ownerId);


### PR DESCRIPTION
# Fix #2157: Optimize Entity Relationships with LAZY Fetching and BatchSize

## Description
This PR addresses issue #2157 by optimizing the fetching strategy for [Owner](cci:2://file:///c:/Users/Shivam%20Jha/Downloads/open_source/spring-petclinic/src/main/java/org/springframework/samples/petclinic/owner/Owner.java:48:0-185:1) and [Pet](cci:2://file:///c:/Users/Shivam%20Jha/Downloads/open_source/spring-petclinic/src/main/java/org/springframework/samples/petclinic/owner/Pet.java:45:0-87:1) entities to resolve the N+1 query problem found during owner searches.

## Changes
- **Optimized Fetching**: Changed `Owner.pets` relationship to `FetchType.LAZY`.
- **Batch Loading**: Added `@BatchSize(size = 10)` to `Owner.pets` and `Pet.visits` to efficiently load related entities in batches, significantly reducing the number of database queries.
- **Entity Updates**: Changed `Pet.visits` and `Pet.type` relationships to `FetchType.LAZY`.
- **Controller Updates**: Updated [OwnerController](cci:2://file:///c:/Users/Shivam%20Jha/Downloads/open_source/spring-petclinic/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java:48:0-189:1), [PetController](cci:2://file:///c:/Users/Shivam%20Jha/Downloads/open_source/spring-petclinic/src/main/java/org/springframework/samples/petclinic/owner/PetController.java:46:0-184:1), and [VisitController](cci:2://file:///c:/Users/Shivam%20Jha/Downloads/open_source/spring-petclinic/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java:41:0-108:1) to handle `LazyInitializationException` (since `spring.jpa.open-in-view` is set to `false`).
    - Added `@Transactional(readOnly = true)` to relevant methods.
    - Explicitly initialized required collections (`pets`, `visits`, `type`) within the controller methods to ensure data is available for the views.

## Verification
- Verified that the application correctly loads Owner details, Pet lists, and Visit information without throwing `LazyInitializationException`.
- Confirmed that related entities are only loaded when needed and in efficient batches, improving performance.

Closes #2157