### PR TITLE
Add validation tests for Person and Owner entities

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.samples.petclinic.owner.Owner;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 import jakarta.validation.ConstraintViolation;
@@ -55,6 +56,62 @@ class ValidatorTests {
 		ConstraintViolation<Person> violation = constraintViolations.iterator().next();
 		assertThat(violation.getPropertyPath()).hasToString("firstName");
 		assertThat(violation.getMessage()).isEqualTo("must not be blank");
+	}
+
+	@Test
+	void shouldNotValidateWhenLastNameEmpty() {
+
+		LocaleContextHolder.setLocale(Locale.ENGLISH);
+		Person person = new Person();
+		person.setFirstName("James");
+		person.setLastName("");
+
+		Validator validator = createValidator();
+		Set<ConstraintViolation<Person>> constraintViolations = validator.validate(person);
+
+		assertThat(constraintViolations).hasSize(1);
+		ConstraintViolation<Person> violation = constraintViolations.iterator().next();
+		assertThat(violation.getPropertyPath()).hasToString("lastName");
+		assertThat(violation.getMessage()).isEqualTo("must not be blank");
+	}
+
+	@Test
+	void shouldNotValidateOwnerWithBlankFieldsAndNonNumericTelephone() {
+
+		LocaleContextHolder.setLocale(Locale.ENGLISH);
+		Owner owner = new Owner();
+		owner.setFirstName("");
+		owner.setLastName("");
+		owner.setAddress("");
+		owner.setCity("");
+		owner.setTelephone("telephone");
+
+		Validator validator = createValidator();
+		Set<ConstraintViolation<Owner>> constraintViolations = validator.validate(owner);
+
+		assertThat(constraintViolations).hasSize(5);
+		assertThat(constraintViolations).extracting(violation -> violation.getPropertyPath().toString())
+			.containsExactlyInAnyOrder("firstName", "lastName", "address", "city", "telephone");
+	}
+
+	@Test
+	void shouldNotValidateOwnerWhenTelephoneIsNonNumeric() {
+
+		LocaleContextHolder.setLocale(Locale.ENGLISH);
+		Owner owner = new Owner();
+		owner.setFirstName("George");
+		owner.setLastName("Franklin");
+		owner.setAddress("110 W. Liberty St.");
+		owner.setCity("Madison");
+		owner.setTelephone("invalid");
+
+		Validator validator = createValidator();
+		Set<ConstraintViolation<Owner>> constraintViolations = validator.validate(owner);
+
+		assertThat(constraintViolations).hasSize(1);
+		ConstraintViolation<Owner> violation = constraintViolations.iterator().next();
+		assertThat(violation.getPropertyPath()).hasToString("telephone");
+		assertThat(violation.getMessage()).isEqualTo("numeric value out of bounds (<10 digits>.<0 digits> expected)");
 	}
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
@@ -115,3 +115,4 @@ class ValidatorTests {
 	}
 
 }
+


### PR DESCRIPTION
This pull request adds new validation tests to the `ValidatorTests` class to improve coverage of the `Person` and `Owner` models, particularly focusing on blank fields and invalid telephone numbers. These tests help ensure that validation constraints are enforced correctly for both models.

New validation tests for `Person` and `Owner`:

* Added a test to verify that a `Person` with an empty `lastName` is not considered valid and produces the expected validation message.
* Added a test to ensure that an `Owner` with all blank fields and a non-numeric telephone number triggers five specific validation errors, one for each invalid property.
* Added a test to check that an `Owner` with a non-numeric telephone number (but otherwise valid fields) fails validation with the correct error message for the `telephone` property.

Test file imports:

* Imported the `Owner` class to support the new validation tests for the `Owner` model.