### PR TITLE
Added /livez and /readyz endpoints using Spring Boot Actuator health probes

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/HealthEndpointController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/HealthEndpointController.java
@@ -1,0 +1,36 @@
+package org.springframework.samples.petclinic.owner;
+
+import org.springframework.boot.health.actuate.endpoint.HealthEndpoint;
+import org.springframework.boot.health.contributor.Status;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+class HealthEndpointController {
+
+	private final HealthEndpoint healthEndpoint;
+
+	public HealthEndpointController(HealthEndpoint healthEndpoint) {
+		this.healthEndpoint = healthEndpoint;
+	}
+
+	// Exposes Kubernetes-compatible liveness endpoint by delegating to Spring Boot
+	// Actuator
+	@GetMapping("/livez")
+	public Map<String, String> livez() {
+		Status status = healthEndpoint.healthForPath("liveness").getStatus();
+		return Map.of("status", status.getCode());
+	}
+
+	// Exposes Kubernetes-compatible readiness endpoint by delegating to Spring Boot
+	// Actuator
+	@GetMapping("/readyz")
+	public Map<String, String> readyz() {
+		Status status = healthEndpoint.healthForPath("readiness").getStatus();
+		return Map.of("status", status.getCode());
+	}
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,6 +17,7 @@ spring.messages.basename=messages/messages
 
 # Actuator
 management.endpoints.web.exposure.include=*
+management.endpoint.health.probes.enabled=true
 
 # Logging
 logging.level.org.springframework=INFO


### PR DESCRIPTION
- Delegate health checks to Actuator
- Expose only status (UP/DOWN)
- Enable health probes for liveness and readiness support