### PR TITLE
docs: fixed minor typo in the README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Our issue tracker is available [here](https://github.com/spring-projects/spring-
 ## Database configuration
 
 In its default configuration, Petclinic uses an in-memory database (H2) which
-gets populated at startup with data. The h2 console is exposed at `http://localhost:8080/h2-console`,
-and it is possible to inspect the content of the database using the `jdbc:h2:mem:<uuid>` URL. The UUID is printed at startup to the console.
+is populated at startup with data. The h2 console is exposed at `http://localhost:8080/h2-console`,
+and you can inspect the database contents using the `jdbc:h2:mem:<uuid>` URL. The UUID is printed at startup in the console.
 
 A similar setup is provided for MySQL and PostgreSQL if a persistent database configuration is needed. Note that whenever the database type changes, the app needs to run with a different profile: `spring.profiles.active=mysql` for MySQL or `spring.profiles.active=postgres` for PostgreSQL. See the [Spring Boot documentation](https://docs.spring.io/spring-boot/how-to/properties-and-configuration.html#howto.properties-and-configuration.set-active-spring-profiles) for more detail on how to set the active profile.
 
@@ -93,7 +93,7 @@ At development time we recommend you use the test applications set up as `main()
 
 ## Compiling the CSS
 
-There is a `petclinic.css` in `src/main/resources/static/resources/css`. It was generated from the `petclinic.scss` source, combined with the [Bootstrap](https://getbootstrap.com/) library. If you make changes to the `scss`, or upgrade Bootstrap, you will need to re-compile the CSS resources using the Maven profile "css", i.e. `./mvnw package -P css`. There is no build profile for Gradle to compile the CSS.
+There is a `petclinic.css` in `src/main/resources/static/resources/css`. It was generated from the `petclinic.scss` source, combined with the [Bootstrap](https://getbootstrap.com/) library. If you make changes to the `scss`, or upgrade Bootstrap, you need to recompile the CSS resources using the Maven profile "css", i.e. `./mvnw package -P css`. There is no build profile for Gradle to compile the CSS.
 
 ## Working with Petclinic in your IDE
 
@@ -104,7 +104,7 @@ The following items should be installed in your system:
 - Java 17 or newer (full JDK, not a JRE)
 - [Git command line tool](https://help.github.com/articles/set-up-git)
 - Your preferred IDE
-  - Eclipse with the m2e plugin. Note: when m2e is available, there is a m2 icon in `Help -> About` dialog. If m2e is
+  - Eclipse with the m2e plugin. Note: when m2e is available, there is an m2 icon in the `Help -> About` dialog. If m2e is
   not there, follow the installation process [here](https://www.eclipse.org/m2e/)
   - [Spring Tools Suite](https://spring.io/tools) (STS)
   - [IntelliJ IDEA](https://www.jetbrains.com/idea/)
@@ -153,7 +153,7 @@ GitHub org is the "canonical" implementation based on Spring Boot and Thymeleaf.
 
 ## Interaction with other open-source projects
 
-One of the best parts about working on the Spring Petclinic application is that we have the opportunity to work in direct contact with many Open Source projects. We found bugs/suggested improvements on various topics such as Spring, Spring Data, Bean Validation and even Eclipse! In many cases, they've been fixed/implemented in just a few days.
+One of the best parts about working on the Spring Petclinic application is that we have the opportunity to work in direct contact with many Open Source projects. We have found bugs/suggested improvements on various topics such as Spring, Spring Data, Bean Validation, and even Eclipse! In many cases, they were fixed/implemented in just a few days.
 Here is a list of them:
 
 | Name | Issue |


### PR DESCRIPTION
This pull request makes minor improvements to the `README.md` file by clarifying language, correcting grammar, and enhancing readability. No functional or technical changes are introduced.
