### PR TITLE
Fix /livez and /readyz returning 404 by enabling health probe paths

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,6 +17,7 @@ spring.messages.basename=messages/messages
 
 # Actuator
 management.endpoints.web.exposure.include=*
+management.endpoint.health.probes.add-additional-paths=true
 
 # Logging
 logging.level.org.springframework=INFO

--- a/src/test/java/org/springframework/samples/petclinic/system/HealthProbeIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/HealthProbeIntegrationTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.system;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Integration tests verifying that Kubernetes liveness ({@code /livez}) and readiness
+ * ({@code /readyz}) health probe endpoints are accessible at the root path level.
+ *
+ * <p>
+ * Spring Boot Actuator exposes these paths when
+ * {@code management.endpoint.health.probes.add-additional-paths=true} is set. Without
+ * this property, {@code /livez} and {@code /readyz} return 404, breaking Kubernetes
+ * health checks defined in {@code k8s/petclinic.yml}.
+ *
+ * @see <a href= "https://github.com/spring-projects/spring-petclinic/issues/2311">Issue
+ * #2311</a>
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT,
+		properties = { "management.endpoint.health.probes.add-additional-paths=true" })
+@AutoConfigureTestRestTemplate
+class HealthProbeIntegrationTests {
+
+	@Value("${local.server.port}")
+	private int port;
+
+	@Autowired
+	private TestRestTemplate rest;
+
+	@Test
+	void livezEndpointReturns200() {
+		ResponseEntity<String> response = rest
+			.exchange(RequestEntity.get("http://localhost:" + port + "/livez").build(), String.class);
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+	}
+
+	@Test
+	void readyzEndpointReturns200() {
+		ResponseEntity<String> response = rest
+			.exchange(RequestEntity.get("http://localhost:" + port + "/readyz").build(), String.class);
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+	}
+
+	@SpringBootApplication(exclude = { DataSourceAutoConfiguration.class,
+			DataSourceTransactionManagerAutoConfiguration.class, HibernateJpaAutoConfiguration.class })
+	static class TestConfiguration {
+
+	}
+
+}


### PR DESCRIPTION
Problem: /livez and /readyz return 404 as reported in #2311. The k8s/petclinic.yml configures Kubernetes liveness and readiness probes on these paths, but the required Spring Boot Actuator property was missing from application.properties.

Fix: Added management.endpoint.health.probes.add-additional-paths=true to application.properties. This is the same property already present in k8s/petclinic.yml via SPRING_APPLICATION_JSON, making behaviour consistent whether running locally or in Kubernetes.

Tests: Added HealthProbeIntegrationTests verifying both /livez and /readyz return HTTP 200.

Closes #2311