### PR TITLE
Change color theme from green to red

### DIFF
--- a/src/main/resources/static/resources/css/petclinic.css
+++ b/src/main/resources/static/resources/css/petclinic.css
@@ -9290,7 +9290,7 @@ textarea.form-control-lg {
   transition: border 0.15s;
   color: #f1f1f1;
   background: #34302D;
-  border-color: #6db33f;
+  border-color: #d9534f;
   -webkit-transition: border 0.15s;
   -moz-transition: border 0.15s;
   -o-transition: border 0.15s;
@@ -9335,7 +9335,7 @@ h1, .h1 {
   display: none; }
 
 .splash {
-  background: #6db33f;
+  background: #d9534f;
   color: #34302D;
   display: none; }
 
@@ -9442,7 +9442,7 @@ strong {
   font-family: "montserratregular", sans-serif; }
 
 .navbar {
-  border-top: 4px solid #6db33f;
+  border-top: 4px solid #d9534f;
   background-color: #34302d;
   margin-bottom: 0px;
   border-bottom: 0;
@@ -9492,7 +9492,7 @@ strong {
 
 .navbar li:hover > a {
   color: #eeeeee;
-  background-color: #6db33f; }
+  background-color: #d9534f; }
 
 .navbar-toggle {
   border-width: 0; }

--- a/src/main/scss/header.scss
+++ b/src/main/scss/header.scss
@@ -1,5 +1,5 @@
 .navbar {
-  border-top: 4px solid #6db33f;
+  border-top: 4px solid #d9534f;
   background-color: #34302d;
   margin-bottom: 0px;
   border-bottom: 0;
@@ -56,7 +56,7 @@
 }
 .navbar li:hover > a {
   color: #eeeeee;
-  background-color: #6db33f;
+  background-color: #d9534f;
 }
 
 .navbar-toggle {

--- a/src/main/scss/petclinic.scss
+++ b/src/main/scss/petclinic.scss
@@ -15,8 +15,8 @@
 
 $icon-font-path:    "../../webjars/bootstrap/fonts/";
 
-$spring-green:      #6db33f;
-$spring-dark-green: #5fa134;
+$spring-green:      #d9534f;
+$spring-dark-green: #c9302c;
 $spring-brown:      #34302D;
 $spring-grey:       #838789;
 $spring-light-grey: #f1f1f1;


### PR DESCRIPTION
Closes #1

## Summary
- Replaced `$spring-green` (`#6db33f`) with red `#d9534f` in `petclinic.scss`
- Replaced `$spring-dark-green` (`#5fa134`) with darker red `#c9302c` in `petclinic.scss`
- Updated two hardcoded green values in `header.scss` (navbar top border and hover background)
- Updated 4 occurrences in the pre-compiled `petclinic.css`

## Test plan
- [x] All 57 tests pass (`./mvnw test`)
- [ ] Visually verify navbar, buttons, links, and splash background render in red

🤖 Generated with [Claude Code](https://claude.com/claude-code)