### PR TITLE
fix: validate page parameter to prevent 500 errors in pagination

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -94,6 +94,12 @@ class OwnerController {
 	@GetMapping("/owners")
 	public String processFindForm(@RequestParam(defaultValue = "1") int page, Owner owner, BindingResult result,
 			Model model) {
+
+		// Guard: page must be >= 1 to prevent IllegalArgumentException
+		if (page < 1) {
+			return "redirect:/owners?page=1";
+		}
+
 		// allow parameterless GET request for /owners to return all records
 		String lastName = owner.getLastName();
 		if (lastName == null) {

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -45,9 +45,21 @@ class VetController {
 	public String showVetList(@RequestParam(defaultValue = "1") int page, Model model) {
 		// Here we are returning an object of type 'Vets' rather than a collection of Vet
 		// objects so it is simpler for Object-Xml mapping
-		Vets vets = new Vets();
+
+		// Guard: page must be >= 1 to prevent IllegalArgumentException
+		// in PageRequest.of(page - 1, pageSize) when page < 1
+		if (page < 1) {
+			return "redirect:/vets.html?page=1";
+		}
+
 		Page<Vet> paginated = findPaginated(page);
-		vets.getVetList().addAll(paginated.toList());
+
+		// Guard: redirect to last page if requested page exceeds total
+		int totalPages = paginated.getTotalPages();
+		if (totalPages > 0 && page > totalPages) {
+			return "redirect:/vets.html?page=" + totalPages;
+		}
+
 		return addPaginationModel(page, paginated, model);
 	}
 

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -248,4 +248,18 @@ class OwnerControllerTests {
 			.andExpect(flash().attributeExists("error"));
 	}
 
+	@Test
+	void processFindFormPageZeroShouldRedirectToPageOne() throws Exception {
+		mockMvc.perform(get("/owners").param("page", "0"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/owners?page=1"));
+	}
+
+	@Test
+	void processFindFormNegativePageShouldRedirectToPageOne() throws Exception {
+		mockMvc.perform(get("/owners").param("page", "-1"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/owners?page=1"));
+	}
+
 }

--- a/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
@@ -97,4 +97,38 @@ class VetControllerTests {
 			.andExpect(jsonPath("$.vetList[0].id").value(1));
 	}
 
+	@Test
+	void showVetListHtmlPageZeroShouldRedirectToPageOne() throws Exception {
+		mockMvc.perform(get("/vets.html").param("page", "0"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/vets.html?page=1"));
+	}
+
+	@Test
+	void showVetListHtmlNegativePageShouldRedirectToPageOne() throws Exception {
+		mockMvc.perform(get("/vets.html").param("page", "-1"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/vets.html?page=1"));
+	}
+
+	@Test
+	void showVetListHtmlPageBeyondTotalShouldRedirectToLastPage() throws Exception {
+		// mock returns 2 vets with pageSize=5 → totalPages=1
+		// so page=999 should redirect to page=1 (the last valid page)
+		mockMvc.perform(get("/vets.html").param("page", "999"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/vets.html?page=1"));
+	}
+
+	@Test
+	void showVetListHtmlValidPageShouldLoadCorrectly() throws Exception {
+		mockMvc.perform(get("/vets.html").param("page", "1"))
+			.andExpect(status().isOk())
+			.andExpect(model().attributeExists("currentPage"))
+			.andExpect(model().attributeExists("totalPages"))
+			.andExpect(model().attributeExists("totalItems"))
+			.andExpect(model().attributeExists("listVets"))
+			.andExpect(view().name("vets/vetList"));
+	}
+
 }


### PR DESCRIPTION
## What does this PR do?
Adds page parameter boundary validation in `VetController` and 
`OwnerController` to prevent unhandled `IllegalArgumentException` 
when invalid page values are provided.

## Problem
Accessing `/vets.html?page=0` or `/owners?page=0` throws:
`IllegalArgumentException: Page index must not be less than zero`
resulting in a 500 Internal Server Error.

Accessing `/vets.html?page=999` returns a silent empty table
with no user feedback and a broken URL.

## Solution
- `page < 1` → redirect to page=1 (both controllers)
- `page > totalPages` → redirect to last valid page (VetController)
- Removes unused `Vets` object from `VetController.showVetList()`

## Testing
- Added 4 tests in `VetControllerTests`
- Added 2 tests in `OwnerControllerTests`
- All existing tests continue to pass

## Checklist
- [x] Tests added
- [x] `./mvnw test` passes locally
- [x] `./mvnw spring-javaformat:apply` applied
- [x] Commit includes Signed-off-by trailer
- [x] Focused on a single concern

Closes #2379