### PR TITLE
Improve documentation for running container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ See below for more details.
 
 There is no `Dockerfile` in this project. You can build a container image (if you have a docker daemon) using the Spring Boot build plugin:
 
+## Running the Container Image
+
 ```bash
 ./mvnw spring-boot:build-image
+docker images | grep petclinic
+docker run -p 8080:8080 docker.io/library/spring-petclinic:latest
 ```
 
 ## In case you find a bug/suggested improvement for Spring Petclinic


### PR DESCRIPTION
The README currently explains how to build a container image using
`spring-boot:build-image`, but does not describe how to run it.

This PR adds a new section with instructions for:
- verifying that the image was created
- running the container
- accessing the application