### PR TITLE
Handle invalid pagination boundaries

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -43,11 +43,19 @@ class VetController {
 
 	@GetMapping("/vets.html")
 	public String showVetList(@RequestParam(defaultValue = "1") int page, Model model) {
-		// Here we are returning an object of type 'Vets' rather than a collection of Vet
-		// objects so it is simpler for Object-Xml mapping
-		Vets vets = new Vets();
+
+		if (page < 1) {
+			return "redirect:/vets.html?page=1";
+		}
+
 		Page<Vet> paginated = findPaginated(page);
+		if (paginated.getTotalPages() > 0 && page > paginated.getTotalPages()) {
+			return "redirect:/vets.html?page=" + paginated.getTotalPages();
+		}
+
+		Vets vets = new Vets();
 		vets.getVetList().addAll(paginated.toList());
+
 		return addPaginationModel(page, paginated, model);
 	}
 

--- a/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
@@ -88,6 +88,23 @@ class VetControllerTests {
 			.andExpect(view().name("vets/vetList"));
 
 	}
+	@Test
+	void shouldRedirectWhenPageLessThanOne() throws Exception {
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/vets.html?page=0"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/vets.html?page=1"));
+
+	}
+
+	@Test
+	void shouldRedirectWhenPageExceedsTotalPages() throws Exception {
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/vets.html?page=999"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/vets.html?page=1"));
+
+	}
 
 	@Test
 	void showResourcesVetList() throws Exception {


### PR DESCRIPTION
## Summary

Fix pagination boundary handling in `VetController` and `OwnerController`.

### Changes

* Redirect requests with `page <= 0` to the first page
* Redirect requests exceeding total pages to the last valid page
* Added controller tests for invalid pagination scenarios

### Problem

Previously:

* `page=0` caused `IllegalArgumentException`
* large page numbers returned empty pages with no feedback

### Result

Pagination now gracefully redirects users to valid page boundaries and avoids server errors.
