### PR TITLE
Fix/add service documentation

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -89,6 +89,10 @@ class OwnerController {
 							+ ". Please ensure the ID is correct " + "and the owner exists in the database."));
 	}
 
+	/**
+	 * Renders the owner creation form.
+	 * @return the logical view name for the create/update owner form
+	 */
 	@GetMapping("/owners/new")
 	public String initCreationForm() {
 		return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -63,6 +63,10 @@ class OwnerController {
 		this.owners = owners;
 	}
 
+	/**
+	 * Prevents clients from directly setting entity identifiers through form binding.
+	 * @param dataBinder the binder to configure
+	 */
 	@InitBinder
 	public void setAllowedFields(WebDataBinder dataBinder) {
 		dataBinder.setDisallowedFields("id", "*.id");

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -39,6 +39,9 @@ import jakarta.validation.Valid;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 /**
+ * Handles HTTP requests for managing {@link Owner} data, including creating, searching,
+ * updating, and displaying owners and their associated pets.
+ *
  * @author Juergen Hoeller
  * @author Ken Krebs
  * @author Arjen Poutsma
@@ -52,6 +55,10 @@ class OwnerController {
 
 	private final OwnerRepository owners;
 
+	/**
+	 * Creates a new {@code OwnerController} backed by the given owner repository.
+	 * @param owners the repository used to load and persist {@link Owner} instances
+	 */
 	public OwnerController(OwnerRepository owners) {
 		this.owners = owners;
 	}

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -164,6 +164,13 @@ class OwnerController {
 		return addPaginationModel(page, model, ownersResults);
 	}
 
+	/**
+	 * Adds pagination-related attributes to the model for the owner list view.
+	 * @param page the current 1-based page number
+	 * @param model the model to populate
+	 * @param paginated the paginated result containing owners for the current page
+	 * @return the logical view name for the owners list page
+	 */
 	private String addPaginationModel(int page, Model model, Page<Owner> paginated) {
 		List<Owner> listOwners = paginated.getContent();
 		model.addAttribute("currentPage", page);

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -201,6 +201,16 @@ class OwnerController {
 		return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;
 	}
 
+	/**
+	 * Processes the owner update form. Saves the updated owner and redirects to the
+	 * owner detail page on success, or returns the form view if validation fails or the
+	 * owner ID in the form does not match the URL.
+	 * @param owner the updated owner data from the submitted form
+	 * @param result binding result containing any validation errors
+	 * @param ownerId the owner identifier from the URL path
+	 * @param redirectAttributes flash attributes for success or error messages
+	 * @return a redirect to the owner detail page, or the form view on error
+	 */
 	@PostMapping("/owners/{ownerId}/edit")
 	public String processUpdateOwnerForm(@Valid Owner owner, BindingResult result, @PathVariable("ownerId") int ownerId,
 			RedirectAttributes redirectAttributes) {

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -98,6 +98,14 @@ class OwnerController {
 		return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;
 	}
 
+	/**
+	 * Processes the owner creation form. Saves the owner and redirects to the owner
+	 * detail page on success, or returns the form view if validation fails.
+	 * @param owner the owner populated from the submitted form
+	 * @param result binding result containing any validation errors
+	 * @param redirectAttributes flash attributes for success or error messages
+	 * @return a redirect to the new owner's detail page, or the form view on error
+	 */
 	@PostMapping("/owners/new")
 	public String processCreationForm(@Valid Owner owner, BindingResult result, RedirectAttributes redirectAttributes) {
 		if (result.hasErrors()) {

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -118,6 +118,10 @@ class OwnerController {
 		return "redirect:/owners/" + owner.getId();
 	}
 
+	/**
+	 * Renders the owner search form.
+	 * @return the logical view name for the find owners page
+	 */
 	@GetMapping("/owners/find")
 	public String initFindForm() {
 		return "owners/findOwners";

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -192,6 +192,10 @@ class OwnerController {
 		return owners.findByLastNameStartingWith(lastname, pageable);
 	}
 
+	/**
+	 * Renders the owner update form, pre-populated with the current owner data.
+	 * @return the logical view name for the create/update owner form
+	 */
 	@GetMapping("/owners/{ownerId}/edit")
 	public String initUpdateOwnerForm() {
 		return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -72,6 +72,15 @@ class OwnerController {
 		dataBinder.setDisallowedFields("id", "*.id");
 	}
 
+	/**
+	 * Loads an existing {@link Owner} when {@code ownerId} is present in the URL, or
+	 * returns a new empty {@link Owner} for creation forms.
+	 * @param ownerId the owner identifier from the URL path, or {@code null} for new
+	 * owner forms
+	 * @return the existing {@link Owner} or a new empty instance
+	 * @throws IllegalArgumentException if {@code ownerId} is provided but no matching
+	 * owner exists
+	 */
 	@ModelAttribute("owner")
 	public Owner findOwner(@PathVariable(name = "ownerId", required = false) Integer ownerId) {
 		return ownerId == null ? new Owner()

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -180,6 +180,12 @@ class OwnerController {
 		return "owners/ownersList";
 	}
 
+	/**
+	 * Retrieves a page of owners whose last name starts with the given value.
+	 * @param page the 1-based page number to retrieve
+	 * @param lastname the last name prefix to filter by
+	 * @return a {@link Page} of matching {@link Owner}s
+	 */
 	private Page<Owner> findPaginatedForOwnersLastName(int page, String lastname) {
 		int pageSize = 5;
 		Pageable pageable = PageRequest.of(page - 1, pageSize);

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -127,6 +127,16 @@ class OwnerController {
 		return "owners/findOwners";
 	}
 
+	/**
+	 * Searches owners by last name with pagination. Redirects to the owner detail page
+	 * when exactly one match is found, or shows a paginated list for multiple results.
+	 * @param page the 1-based page number requested
+	 * @param owner the search criteria holder; {@code lastName} is used as the filter
+	 * @param result binding result for registering field-level errors
+	 * @param model the model to populate with pagination attributes
+	 * @return a redirect to the owner detail page, the owners list view, or the search
+	 * form if no owners are found
+	 */
 	@GetMapping("/owners")
 	public String processFindForm(@RequestParam(defaultValue = "1") int page, Owner owner, BindingResult result,
 			Model model) {

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -135,6 +135,12 @@ class PetController {
 		dataBinder.setDisallowedFields("id", "*.id");
 	}
 
+	/**
+	 * Renders the pet creation form, adding a new unsaved {@link Pet} to the owner.
+	 * @param owner the owner to whom the new pet will belong
+	 * @param model the model map shared with the view
+	 * @return the logical view name for the create/update pet form
+	 */
 	@GetMapping("/pets/new")
 	public String initCreationForm(Owner owner, ModelMap model) {
 		Pet pet = new Pet();

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -66,6 +66,11 @@ class PetController {
 		this.types = types;
 	}
 
+	/**
+	 * Populates the model with all available pet types for use in pet creation and update
+	 * forms.
+	 * @return a collection of all known {@link PetType}s
+	 */
 	@ModelAttribute("types")
 	public Collection<PetType> populatePetTypes() {
 		return this.types.findPetTypes();

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -148,6 +148,16 @@ class PetController {
 		return VIEWS_PETS_CREATE_OR_UPDATE_FORM;
 	}
 
+	/**
+	 * Processes the pet creation form. Validates that the pet name is unique for the
+	 * owner and that the birth date is not in the future. Saves the pet on success or
+	 * returns the form view with errors.
+	 * @param owner the owner to whom the pet will be added
+	 * @param pet the new pet populated from the submitted form
+	 * @param result binding result containing any validation errors
+	 * @param redirectAttributes flash attributes for passing a success message
+	 * @return a redirect to the owner detail page on success, or the form view on error
+	 */
 	@PostMapping("/pets/new")
 	public String processCreationForm(Owner owner, @Valid Pet pet, BindingResult result,
 			RedirectAttributes redirectAttributes) {

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -181,6 +181,10 @@ class PetController {
 		return "redirect:/owners/{ownerId}";
 	}
 
+	/**
+	 * Renders the pet update form, pre-populated with the current pet data.
+	 * @return the logical view name for the create/update pet form
+	 */
 	@GetMapping("/pets/{petId}/edit")
 	public String initUpdateForm() {
 		return VIEWS_PETS_CREATE_OR_UPDATE_FORM;

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -38,6 +38,9 @@ import jakarta.validation.Valid;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 /**
+ * Handles HTTP requests for managing {@link Pet}s belonging to a specific {@link Owner},
+ * including creating and updating pets under the {@code /owners/{ownerId}} base path.
+ *
  * @author Juergen Hoeller
  * @author Ken Krebs
  * @author Arjen Poutsma
@@ -53,6 +56,11 @@ class PetController {
 
 	private final PetTypeRepository types;
 
+	/**
+	 * Creates a new {@code PetController} backed by the given repositories.
+	 * @param owners the repository used to load and persist {@link Owner} instances
+	 * @param types the repository used to retrieve all available {@link PetType}s
+	 */
 	public PetController(OwnerRepository owners, PetTypeRepository types) {
 		this.owners = owners;
 		this.types = types;

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -113,6 +113,11 @@ class PetController {
 		return owner.getPet(petId);
 	}
 
+	/**
+	 * Prevents clients from directly setting entity identifiers on {@link Owner} objects
+	 * through form binding.
+	 * @param dataBinder the binder to configure
+	 */
 	@InitBinder("owner")
 	public void initOwnerBinder(WebDataBinder dataBinder) {
 		dataBinder.setDisallowedFields("id", "*.id");

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -190,6 +190,16 @@ class PetController {
 		return VIEWS_PETS_CREATE_OR_UPDATE_FORM;
 	}
 
+	/**
+	 * Processes the pet update form. Validates that the updated name does not duplicate
+	 * another pet on the same owner and that the birth date is not in the future. Saves
+	 * the changes on success or returns the form view with errors.
+	 * @param owner the owner of the pet being updated
+	 * @param pet the pet with updated values from the submitted form
+	 * @param result binding result containing any validation errors
+	 * @param redirectAttributes flash attributes for passing a success message
+	 * @return a redirect to the owner detail page on success, or the form view on error
+	 */
 	@PostMapping("/pets/{petId}/edit")
 	public String processUpdateForm(Owner owner, @Valid Pet pet, BindingResult result,
 			RedirectAttributes redirectAttributes) {

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -90,6 +90,15 @@ class PetController {
 		return owner;
 	}
 
+	/**
+	 * Loads an existing {@link Pet} when {@code petId} is present in the URL, or returns
+	 * a new empty {@link Pet} for creation forms.
+	 * @param ownerId the identifier of the owning {@link Owner}
+	 * @param petId the pet identifier from the URL path, or {@code null} for new pet
+	 * forms
+	 * @return the existing {@link Pet} or a new empty instance
+	 * @throws IllegalArgumentException if the owner does not exist
+	 */
 	@ModelAttribute("pet")
 	public Pet findPet(@PathVariable("ownerId") int ownerId,
 			@PathVariable(name = "petId", required = false) Integer petId) {

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -76,6 +76,12 @@ class PetController {
 		return this.types.findPetTypes();
 	}
 
+	/**
+	 * Loads the {@link Owner} with the given identifier for use in model binding.
+	 * @param ownerId the identifier of the owner from the URL path
+	 * @return the matching {@link Owner}
+	 * @throws IllegalArgumentException if no owner with the given identifier exists
+	 */
 	@ModelAttribute("owner")
 	public Owner findOwner(@PathVariable("ownerId") int ownerId) {
 		Optional<Owner> optionalOwner = this.owners.findById(ownerId);

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -123,6 +123,12 @@ class PetController {
 		dataBinder.setDisallowedFields("id", "*.id");
 	}
 
+	/**
+	 * Configures the data binder for {@link Pet} objects, registering
+	 * {@link PetValidator} for validation and preventing clients from setting entity
+	 * identifiers.
+	 * @param dataBinder the binder to configure
+	 */
 	@InitBinder("pet")
 	public void initPetBinder(WebDataBinder dataBinder) {
 		dataBinder.setValidator(new PetValidator());

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -64,6 +64,13 @@ class VetController {
 		return addPaginationModel(page, paginated, model);
 	}
 
+	/**
+	 * Adds pagination-related attributes to the model for the vet list view.
+	 * @param page the current 1-based page number
+	 * @param paginated the paginated result containing vets for the current page
+	 * @param model the model to populate
+	 * @return the logical view name for the vet list page
+	 */
 	private String addPaginationModel(int page, Page<Vet> paginated, Model model) {
 		List<Vet> listVets = paginated.getContent();
 		model.addAttribute("currentPage", page);

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -80,6 +80,12 @@ class VetController {
 		return "vets/vetList";
 	}
 
+	/**
+	 * Retrieves a page of vets for the given 1-based page number, using a fixed page
+	 * size of 5.
+	 * @param page the 1-based page number to retrieve
+	 * @return a {@link Page} of {@link Vet}s for the requested page
+	 */
 	private Page<Vet> findPaginated(int page) {
 		int pageSize = 5;
 		Pageable pageable = PageRequest.of(page - 1, pageSize);

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -92,6 +92,10 @@ class VetController {
 		return vetRepository.findAll(pageable);
 	}
 
+	/**
+	 * Returns all veterinarians as a JSON response body.
+	 * @return a {@link Vets} wrapper containing all {@link Vet} instances
+	 */
 	@GetMapping({ "/vets" })
 	public @ResponseBody Vets showResourcesVetList() {
 		// Here we are returning an object of type 'Vets' rather than a collection of Vet

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -48,6 +48,12 @@ class VetController {
 		this.vetRepository = vetRepository;
 	}
 
+	/**
+	 * Displays a paginated HTML list of all veterinarians.
+	 * @param page the 1-based page number to display; defaults to {@code 1}
+	 * @param model the model to populate with pagination and vet list attributes
+	 * @return the logical view name for the vet list page
+	 */
 	@GetMapping("/vets.html")
 	public String showVetList(@RequestParam(defaultValue = "1") int page, Model model) {
 		// Here we are returning an object of type 'Vets' rather than a collection of Vet

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -27,6 +27,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
+ * Handles HTTP requests for displaying {@link Vet} information, supporting both a
+ * paginated HTML list view and a JSON resource endpoint.
+ *
  * @author Juergen Hoeller
  * @author Mark Fisher
  * @author Ken Krebs
@@ -37,6 +40,10 @@ class VetController {
 
 	private final VetRepository vetRepository;
 
+	/**
+	 * Creates a new {@code VetController} backed by the given vet repository.
+	 * @param vetRepository the repository used to retrieve {@link Vet} data
+	 */
 	public VetController(VetRepository vetRepository) {
 		this.vetRepository = vetRepository;
 	}


### PR DESCRIPTION
## Summary
Adds comprehensive Javadoc to `OwnerController`, `PetController`, and `VetController` — covering class descriptions, constructors, and all methods. No behavioural changes.

## The code issues
- **`OwnerController.java`** — Class description absent; 9 of 10 methods had no Javadoc. Only `showOwner` carried a minimal comment.
- **`PetController.java`** — Class description absent; 8 of 9 methods had no Javadoc. Only `updatePetDetails` was documented.
- **`VetController.java`** — Class description absent; all 4 methods and the constructor had no Javadoc.

## Why these matter
- **Maintainability**: undocumented method contracts force developers to read the full implementation to understand expected inputs, outputs, and error conditions, increasing the cost of every future change.
- **Onboarding**: controllers are the primary entry points into the application. New contributors encounter them first, yet had no inline guidance on routing behaviour, pagination conventions, or redirect semantics.
- **Tooling**: IDEs surface Javadoc as hover tooltips and in auto-generated API docs. Without it, developers lose the fastest path to understanding method contracts.

## What this PR does
- Adds a class-level description to each controller explaining its responsibility and base URL scope.
- Documents each constructor with `@param` tags describing injected dependencies and their roles.
- Documents each method with a description of its behaviour, `@param` tags for all parameters, `@return` for all non-void methods, and `@throws` where applicable.

## SonarQube findings addressed
| Rule  | File                   | Change                                              |
|-------|------------------------|-----------------------------------------------------|
| S1176 | `OwnerController.java` | Javadoc added to class, constructor, and 9 methods  |
| S1176 | `PetController.java`   | Javadoc added to class, constructor, and 8 methods  |
| S1176 | `VetController.java`   | Javadoc added to class, constructor, and 4 methods  |

## Verification
- No logic was changed; all existing tests pass unchanged.
- Each Javadoc addition was committed individually to allow per-method review.