### PR TITLE
[FIX] Remove unnecessary imports (also avoid wildcard imports)

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -47,7 +47,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 /**
  * Test class for {@link OwnerController}

--- a/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
@@ -34,7 +34,11 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 /**
  * Test class for the {@link VetController}


### PR DESCRIPTION
## Remove wildcard imports in test files

### Summary
Replaced wildcard static imports with explicit imports to improve code clarity and maintainability.

### Changes
- **VetControllerTests.java**: Replaced `import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*` with explicit imports for `content`, `jsonPath`, `model`, `status`, `view`
- **OwnerControllerTests.java**: Replaced `import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*` with explicit imports for `flash`, `model`, `redirectedUrl`, `status`, `view`

### Why
- Explicit imports make it clear which classes/methods are actually used
- Reduces potential for naming conflicts
- Improves IDE performance and code navigation
- Follows Java best practices and common style guides

### Testing Instructions

1. **Compile the project**
   ```bash 
    ./mvnw compile
2. **Compile tests **
   ```bash 
    ./mvnw test-compile
3. **Run the affected test classes**
   ```bash 
    ./mvnw test "-Dtest=VetControllerTests,OwnerControllerTests"
4. **Run full test suite** (optional)
   ```bash 
    ./mvnw test