### PR TITLE
Add Javadoc comments to repository classes

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
@@ -27,6 +27,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * Data. See:
  * https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.query-methods.query-creation
  *
+ * <p>This repository provides CRUD operations for {@link Owner} entities, as well as
+ * custom query methods for searching owners by last name and retrieving them by ID.
+ * It extends {@link org.springframework.data.jpa.repository.JpaRepository} to leverage
+ * full JPA support including pagination and sorting.
+ *
  * @author Ken Krebs
  * @author Juergen Hoeller
  * @author Sam Brannen

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetTypeRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetTypeRepository.java
@@ -24,6 +24,10 @@ import org.springframework.data.jpa.repository.Query;
 /**
  * Repository class for <code>PetType</code> domain objects.
  *
+ * <p>Provides data access operations for {@link PetType} entities, including a custom
+ * query to retrieve all pet types ordered alphabetically by name. Extends
+ * {@link org.springframework.data.jpa.repository.JpaRepository} for full JPA support.
+ *
  * @author Patrick Baumgartner
  */
 

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetRepository.java
@@ -47,9 +47,8 @@ public interface VetRepository extends Repository<Vet, Integer> {
 
 	/**
 	 * Retrieve all <code>Vet</code>s from data store in Pages
-	 * @param pageable
-	 * @return
-	 * @throws DataAccessException
+	 * @param pageable the pagination information (page number, page size, sorting)
+	 * @return a {@link Page} containing the {@link Vet} objects for the requested page
 	 */
 	@Transactional(readOnly = true)
 	@Cacheable("vets")


### PR DESCRIPTION
Added Javadoc documentation to three repository classes as part of improving code sustainability.

Changes made:
- VetRepository: filled in missing descriptions for @param and @return in the paginated findAll() method
- OwnerRepository: added more detail to the class-level comment to better explain what the repository does
- PetTypeRepository: added a class-level comment describing the repository's purpose and how it works