### PR TITLE
feat: Audit trail with jpa Implemented

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/PetClinicApplication.java
+++ b/src/main/java/org/springframework/samples/petclinic/PetClinicApplication.java
@@ -19,6 +19,7 @@ package org.springframework.samples.petclinic;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ImportRuntimeHints;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 /**
  * PetClinic Spring Boot Application.
@@ -27,6 +28,7 @@ import org.springframework.context.annotation.ImportRuntimeHints;
  */
 @SpringBootApplication
 @ImportRuntimeHints(PetClinicRuntimeHints.class)
+@EnableJpaAuditing
 public class PetClinicApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java
@@ -16,7 +16,15 @@
 package org.springframework.samples.petclinic.model;
 
 import java.io.Serializable;
+import java.time.LocalDate;
 
+import org.springframework.boot.actuate.audit.listener.AuditListener;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -28,13 +36,35 @@ import jakarta.persistence.MappedSuperclass;
  *
  * @author Ken Krebs
  * @author Juergen Hoeller
+ * @author Hardik Limbachiya
  */
 @MappedSuperclass
+@EntityListeners(AuditListener.class)
 public class BaseEntity implements Serializable {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer id;
+	
+	@CreatedDate
+	private LocalDate createdAt;
+	
+	@CreatedBy
+	@Column(updatable =  false)
+	private String createdBy;
+	
+    @LastModifiedBy
+    private String modifiedBy;
+    
+    
+
+	public String getCreatedBy() {
+		return createdBy;
+	}
+
+	public String getModifiedBy() {
+		return modifiedBy;
+	}
 
 	public Integer getId() {
 		return id;
@@ -47,5 +77,7 @@ public class BaseEntity implements Serializable {
 	public boolean isNew() {
 		return this.id == null;
 	}
+	
+	public LocalDate getCreatedAt() {return createdAt;}
 
 }


### PR DESCRIPTION
## Summary
Added audit trail support to `BaseEntity` using Spring Data JPA Auditing.

## Changes
- Annotated `BaseEntity` with `@MappedSuperclass` and `@EntityListeners(AuditListener.class)`
- Added `createdAt` field using `@CreatedDate` to capture entity creation time
- Added `createdBy` field using `@CreatedBy` (non-updatable) to track who created the record
- Added `modifiedBy` field using `@LastModifiedBy` to track who last modified the record

## Why
Audit trails are essential for tracking data changes in enterprise applications.
This implementation ensures all entities extending `BaseEntity` automatically
get audit metadata without any additional code.
