### PR TITLE
Refactor i18n file scanning to reduce memory usage

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/system/I18nPropertiesSyncTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/I18nPropertiesSyncTest.java
@@ -51,28 +51,33 @@ public class I18nPropertiesSyncTest {
 		StringBuilder report = new StringBuilder();
 
 		for (Path file : files) {
-			List<String> lines = Files.readAllLines(file);
-			for (int i = 0; i < lines.size(); i++) {
-				String line = lines.get(i).trim();
+			try (var reader = Files.newBufferedReader(file)) {
+				String rawLine;
+				int lineNumber = 0;
 
-				if (line.startsWith("//") || line.startsWith("@") || line.contains("log.")
-						|| line.contains("System.out")) {
-					continue;
-				}
+				while ((rawLine = reader.readLine()) != null) {
+					lineNumber++;
+					String line = rawLine.trim();
 
-				if (file.toString().endsWith(".html")) {
-					boolean hasLiteralText = HTML_TEXT_LITERAL.matcher(line).find();
-					boolean hasThTextAttribute = HAS_TH_TEXT_ATTRIBUTE.matcher(line).find();
-					boolean isBracketOnly = BRACKET_ONLY.matcher(line).find();
+					if (line.startsWith("//") || line.startsWith("@") || line.contains("log.")
+							|| line.contains("System.out")) {
+						continue;
+					}
 
-					if (hasLiteralText && !line.contains("#{") && !hasThTextAttribute && !isBracketOnly) {
-						report.append("HTML: ")
-							.append(file)
-							.append(" Line ")
-							.append(i + 1)
-							.append(": ")
-							.append(line)
-							.append("\n");
+					if (file.toString().endsWith(".html")) {
+						boolean hasLiteralText = HTML_TEXT_LITERAL.matcher(line).find();
+						boolean hasThTextAttribute = HAS_TH_TEXT_ATTRIBUTE.matcher(line).find();
+						boolean isBracketOnly = BRACKET_ONLY.matcher(line).find();
+
+						if (hasLiteralText && !line.contains("#{") && !hasThTextAttribute && !isBracketOnly) {
+							report.append("HTML: ")
+								.append(file)
+								.append(" Line ")
+								.append(lineNumber)
+								.append(": ")
+								.append(line)
+								.append("\n");
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Refactored the file scanning logic in `I18nPropertiesSyncTest.java` to reduce memory usage during the internationalization string check.

## Changes

- Replaced `Files.readAllLines(file)` with `Files.newBufferedReader(file)`.
- Processed each file line by line instead of loading the full file into memory.
- Wrapped the reader in a try-with-resources block so the file resource is closed automatically.
- Preserved the existing hardcoded HTML string detection logic and line number reporting.

## Sustainability Improvement

The previous implementation loaded every scanned file fully into memory before processing. This could increase peak memory usage, especially as the project grows or when tests run frequently in CI. The updated implementation reads each file incrementally and automatically releases the reader resource after use.

This improves code sustainability by minimizing resource usage and following the try-with-resources practice required for the resource usage criterion.