### PR TITLE
refactor: removing redundant code

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -97,9 +97,7 @@ class PetController {
 	}
 
 	@GetMapping("/pets/new")
-	public String initCreationForm(Owner owner, ModelMap model) {
-		Pet pet = new Pet();
-		owner.addPet(pet);
+	public String initCreationForm() {
 		return VIEWS_PETS_CREATE_OR_UPDATE_FORM;
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.ModelMap;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.BindingResult;

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -45,9 +45,7 @@ class VetController {
 	public String showVetList(@RequestParam(defaultValue = "1") int page, Model model) {
 		// Here we are returning an object of type 'Vets' rather than a collection of Vet
 		// objects so it is simpler for Object-Xml mapping
-		Vets vets = new Vets();
 		Page<Vet> paginated = findPaginated(page);
-		vets.getVetList().addAll(paginated.toList());
 		return addPaginationModel(page, paginated, model);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -43,8 +43,6 @@ class VetController {
 
 	@GetMapping("/vets.html")
 	public String showVetList(@RequestParam(defaultValue = "1") int page, Model model) {
-		// Here we are returning an object of type 'Vets' rather than a collection of Vet
-		// objects so it is simpler for Object-Xml mapping
 		Page<Vet> paginated = findPaginated(page);
 		return addPaginationModel(page, paginated, model);
 	}


### PR DESCRIPTION
## What

Removes two pieces of unused code in the web tier:

### 1. `VetController.showVetList`

Removed a `Vets` object that was constructed, populated via `vets.getVetList().addAll(paginated.toList())`, and then never read. The method's return value is built by `addPaginationModel(page, paginated, model)`, which consumes `paginated` directly and exposes its content as the `listVets` model attribute.

### 2. `PetController.initCreationForm`

Three related removals:

- **`ModelMap model` parameter** - declared but never referenced.
- **`Pet pet = new Pet(); owner.addPet(pet);`** - constructed a transient Pet that was never returned, never persisted (this is a `GET` handler that does not call `owners.save(...)`), and never reached the view (the `pet` model attribute is supplied by the `@ModelAttribute("pet") findPet(...)` method, which constructs its own `new Pet()`). The mutation therefore had no observable effect.
- **`Owner owner` parameter** - with the body emptied, this parameter is no longer referenced either. Spring still resolves the `owner` model attribute through `@ModelAttribute("owner") findOwner(...)`, so the view receives the same data.
- **`org.springframework.ui.ModelMap` import** - now unused following the parameter removal.

## Verification

`./mvnw test` passes unchanged. No tests were modified.

## Review checklist

- [ ] No surviving references to the deleted local `vets` variable in
      `VetController`.
- [ ] No surviving references to the deleted `ModelMap model` or
      `Owner owner` parameters in `PetController.initCreationForm`.
- [ ] `org.springframework.ui.ModelMap` import removed from
      `PetController`.
- [ ] Existing tests pass without modification.