### PR TITLE
Add Javadoc to OwnerController

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -39,6 +39,16 @@ import jakarta.validation.Valid;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 /**
+ * Spring MVC controller that coordinates all HTTP-facing owner operations
+ * for the PetClinic application.
+ *
+ * <p>
+ * Acts as part of the service/business-logic layer by translating web requests
+ * into operations on the {@link OwnerRepository}, applying validation, and
+ * selecting the appropriate Thymeleaf view. Supported flows include creating a
+ * new owner, searching owners by last name (with pagination), viewing owner
+ * details, and editing an existing owner.
+ *
  * @author Juergen Hoeller
  * @author Ken Krebs
  * @author Arjen Poutsma
@@ -56,11 +66,26 @@ class OwnerController {
 		this.owners = owners;
 	}
 
+	/**
+	 * Restricts which form fields may be bound from incoming requests. The
+	 * {@code id} fields are disallowed so that callers cannot overwrite the
+	 * primary key of an owner (or nested entity) through form submission.
+	 * @param dataBinder the binder used for the current request
+	 */
 	@InitBinder
 	public void setAllowedFields(WebDataBinder dataBinder) {
 		dataBinder.setDisallowedFields("id", "*.id");
 	}
 
+	/**
+	 * Resolves the {@link Owner} model attribute used by the create and edit
+	 * forms. Returns a new, empty {@code Owner} when no path variable is
+	 * present (creation flow), or loads the persisted owner by id (edit flow).
+	 * @param ownerId the id of the owner to load, or {@code null} for creation
+	 * @return the resolved owner instance
+	 * @throws IllegalArgumentException if {@code ownerId} is provided but no
+	 * matching owner exists
+	 */
 	@ModelAttribute("owner")
 	public Owner findOwner(@PathVariable(name = "ownerId", required = false) Integer ownerId) {
 		return ownerId == null ? new Owner()
@@ -69,11 +94,24 @@ class OwnerController {
 							+ ". Please ensure the ID is correct " + "and the owner exists in the database."));
 	}
 
+	/**
+	 * Renders the empty form used to create a new owner.
+	 * @return the logical view name of the create/update owner form
+	 */
 	@GetMapping("/owners/new")
 	public String initCreationForm() {
 		return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;
 	}
 
+	/**
+	 * Persists a new owner submitted from the creation form. On validation
+	 * failure the form is redisplayed with an error flash message; on success
+	 * the user is redirected to the new owner's details page.
+	 * @param owner the bound owner to validate and save
+	 * @param result the binding result holding any validation errors
+	 * @param redirectAttributes used to carry flash messages across redirects
+	 * @return the logical view name or redirect target
+	 */
 	@PostMapping("/owners/new")
 	public String processCreationForm(@Valid Owner owner, BindingResult result, RedirectAttributes redirectAttributes) {
 		if (result.hasErrors()) {
@@ -86,11 +124,27 @@ class OwnerController {
 		return "redirect:/owners/" + owner.getId();
 	}
 
+	/**
+	 * Renders the form that lets users search for owners by last name.
+	 * @return the logical view name of the find-owners form
+	 */
 	@GetMapping("/owners/find")
 	public String initFindForm() {
 		return "owners/findOwners";
 	}
 
+	/**
+	 * Handles the owner search. An empty last name returns all owners
+	 * (broadest possible search). When exactly one owner matches, the user is
+	 * redirected directly to that owner's details; multiple matches are shown
+	 * as a paginated list; no matches re-renders the search form with a
+	 * "not found" validation error.
+	 * @param page the 1-based page number to display
+	 * @param owner the owner form-backing object carrying the search criteria
+	 * @param result the binding result used to report a not-found condition
+	 * @param model the UI model populated with pagination data when needed
+	 * @return the view name (search form, owners list, or redirect to details)
+	 */
 	@GetMapping("/owners")
 	public String processFindForm(@RequestParam(defaultValue = "1") int page, Owner owner, BindingResult result,
 			Model model) {
@@ -133,11 +187,27 @@ class OwnerController {
 		return owners.findByLastNameStartingWith(lastname, pageable);
 	}
 
+	/**
+	 * Renders the prefilled form used to edit an existing owner. The owner is
+	 * loaded into the model by {@link #findOwner(Integer)}.
+	 * @return the logical view name of the create/update owner form
+	 */
 	@GetMapping("/owners/{ownerId}/edit")
 	public String initUpdateOwnerForm() {
 		return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;
 	}
 
+	/**
+	 * Persists edits to an existing owner. Validation failures redisplay the
+	 * form; a mismatch between the form's owner id and the URL path variable
+	 * is treated as a binding error and redirects back to the edit form. On
+	 * success the updated owner's details page is shown.
+	 * @param owner the bound owner carrying the submitted edits
+	 * @param result the binding result holding any validation errors
+	 * @param ownerId the owner id taken from the URL path
+	 * @param redirectAttributes used to carry flash messages across redirects
+	 * @return the logical view name or redirect target
+	 */
 	@PostMapping("/owners/{ownerId}/edit")
 	public String processUpdateOwnerForm(@Valid Owner owner, BindingResult result, @PathVariable("ownerId") int ownerId,
 			RedirectAttributes redirectAttributes) {


### PR DESCRIPTION
Adds class-level Javadoc explaining OwnerController's role as part of the service/business-logic layer (the assignment's "service module", as the business-logic layer since this repo has no service package), plus Javadoc on every public handler method covering purpose, parameters, return values, and notable failure modes. No behavioural changes; existing functionality and tests are unchanged.