### PR TITLE
Avoid redundant coding (Unused code)

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
@@ -44,8 +44,8 @@ public class NamedEntity extends BaseEntity {
 
 	@Override
 	public String toString() {
-		String name = this.getName();
-		return name != null ? name : "<null>";
+		String entityName = this.getName();
+		return entityName != null ? entityName : "<null>";
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -48,6 +48,8 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 @Controller
 class OwnerController {
 
+	private static final String ERROR_ATTRIBUTE = "error";
+
 	private static final String VIEWS_OWNER_CREATE_OR_UPDATE_FORM = "owners/createOrUpdateOwnerForm";
 
 	private final OwnerRepository owners;
@@ -77,7 +79,7 @@ class OwnerController {
 	@PostMapping("/owners/new")
 	public String processCreationForm(@Valid Owner owner, BindingResult result, RedirectAttributes redirectAttributes) {
 		if (result.hasErrors()) {
-			redirectAttributes.addFlashAttribute("error", "There was an error in creating the owner.");
+			redirectAttributes.addFlashAttribute(ERROR_ATTRIBUTE, "There was an error in creating the owner.");
 			return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;
 		}
 
@@ -142,13 +144,13 @@ class OwnerController {
 	public String processUpdateOwnerForm(@Valid Owner owner, BindingResult result, @PathVariable("ownerId") int ownerId,
 			RedirectAttributes redirectAttributes) {
 		if (result.hasErrors()) {
-			redirectAttributes.addFlashAttribute("error", "There was an error in updating the owner.");
+			redirectAttributes.addFlashAttribute(ERROR_ATTRIBUTE, "There was an error in updating the owner.");
 			return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;
 		}
 
 		if (!Objects.equals(owner.getId(), ownerId)) {
 			result.rejectValue("id", "mismatch", "The owner ID in the form does not match the URL.");
-			redirectAttributes.addFlashAttribute("error", "Owner ID mismatch. Please try again.");
+			redirectAttributes.addFlashAttribute(ERROR_ATTRIBUTE, "Owner ID mismatch. Please try again.");
 			return "redirect:/owners/{ownerId}/edit";
 		}
 

--- a/src/main/java/org/springframework/samples/petclinic/vet/Vets.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Vets.java
@@ -30,14 +30,14 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 public class Vets {
 
-	private List<Vet> vets;
+	private List<Vet> vetList;
 
 	@XmlElement
 	public List<Vet> getVetList() {
-		if (vets == null) {
-			vets = new ArrayList<>();
+		if (vetList == null) {
+			vetList = new ArrayList<>();
 		}
-		return vets;
+		return vetList;
 	}
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
@@ -60,8 +60,8 @@ class MySqlIntegrationTests {
 
 	@Test
 	void findAll() {
-		vets.findAll();
-		vets.findAll(); // served from cache
+		assertThat(vets.findAll()).isNotEmpty();
+		assertThat(vets.findAll()).isNotEmpty(); // served from cache
 	}
 
 	@Test

--- a/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationTests.java
@@ -45,8 +45,8 @@ public class PetClinicIntegrationTests {
 
 	@Test
 	void findAll() {
-		vets.findAll();
-		vets.findAll(); // served from cache
+		assertThat(vets.findAll()).isNotEmpty();
+		assertThat(vets.findAll()).isNotEmpty(); // served from cache
 	}
 
 	@Test

--- a/src/test/java/org/springframework/samples/petclinic/PostgresIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PostgresIntegrationTests.java
@@ -80,8 +80,8 @@ public class PostgresIntegrationTests {
 
 	@Test
 	void findAll() throws Exception {
-		vets.findAll();
-		vets.findAll(); // served from cache
+		assertThat(vets.findAll()).isNotEmpty();
+		assertThat(vets.findAll()).isNotEmpty(); // served from cache
 	}
 
 	@Test

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
@@ -48,11 +48,11 @@ class PetValidatorTests {
 
 	private Errors errors;
 
-	private static final String petName = "Buddy";
+	private static final String PET_NAME = "Buddy";
 
-	private static final String petTypeName = "Dog";
+	private static final String PET_TYPE_NAME = "Dog";
 
-	private static final LocalDate petBirthDate = LocalDate.of(1990, 1, 1);
+	private static final LocalDate PET_BIRTH_DATE = LocalDate.of(1990, 1, 1);
 
 	@BeforeEach
 	void setUp() {
@@ -64,10 +64,10 @@ class PetValidatorTests {
 
 	@Test
 	void validate() {
-		petType.setName(petTypeName);
-		pet.setName(petName);
+		petType.setName(PET_TYPE_NAME);
+		pet.setName(PET_NAME);
 		pet.setType(petType);
-		pet.setBirthDate(petBirthDate);
+		pet.setBirthDate(PET_BIRTH_DATE);
 
 		petValidator.validate(pet, errors);
 
@@ -79,10 +79,10 @@ class PetValidatorTests {
 
 		@Test
 		void validateWithInvalidPetName() {
-			petType.setName(petTypeName);
+			petType.setName(PET_TYPE_NAME);
 			pet.setName("");
 			pet.setType(petType);
-			pet.setBirthDate(petBirthDate);
+			pet.setBirthDate(PET_BIRTH_DATE);
 
 			petValidator.validate(pet, errors);
 
@@ -91,9 +91,9 @@ class PetValidatorTests {
 
 		@Test
 		void validateWithInvalidPetType() {
-			pet.setName(petName);
+			pet.setName(PET_NAME);
 			pet.setType(null);
-			pet.setBirthDate(petBirthDate);
+			pet.setBirthDate(PET_BIRTH_DATE);
 
 			petValidator.validate(pet, errors);
 
@@ -102,8 +102,8 @@ class PetValidatorTests {
 
 		@Test
 		void validateWithInvalidBirthDate() {
-			petType.setName(petTypeName);
-			pet.setName(petName);
+			petType.setName(PET_TYPE_NAME);
+			pet.setName(PET_NAME);
 			pet.setType(petType);
 			pet.setBirthDate(null);
 

--- a/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/ClinicServiceTests.java
@@ -86,11 +86,11 @@ class ClinicServiceTests {
 
 	@Test
 	void shouldFindOwnersByLastName() {
-		Page<Owner> owners = this.owners.findByLastNameStartingWith("Davis", pageable);
-		assertThat(owners).hasSize(2);
+		Page<Owner> ownerPage = this.owners.findByLastNameStartingWith("Davis", pageable);
+		assertThat(ownerPage).hasSize(2);
 
-		owners = this.owners.findByLastNameStartingWith("Daviss", pageable);
-		assertThat(owners).isEmpty();
+		ownerPage = this.owners.findByLastNameStartingWith("Daviss", pageable);
+		assertThat(ownerPage).isEmpty();
 	}
 
 	@Test
@@ -107,8 +107,8 @@ class ClinicServiceTests {
 	@Test
 	@Transactional
 	void shouldInsertOwner() {
-		Page<Owner> owners = this.owners.findByLastNameStartingWith("Schultz", pageable);
-		int found = (int) owners.getTotalElements();
+		Page<Owner> ownerPage = this.owners.findByLastNameStartingWith("Schultz", pageable);
+		int found = (int) ownerPage.getTotalElements();
 
 		Owner owner = new Owner();
 		owner.setFirstName("Sam");
@@ -119,8 +119,8 @@ class ClinicServiceTests {
 		this.owners.save(owner);
 		assertThat(owner.getId()).isNotZero();
 
-		owners = this.owners.findByLastNameStartingWith("Schultz", pageable);
-		assertThat(owners.getTotalElements()).isEqualTo(found + 1);
+		ownerPage = this.owners.findByLastNameStartingWith("Schultz", pageable);
+		assertThat(ownerPage.getTotalElements()).isEqualTo(found + 1);
 	}
 
 	@Test
@@ -163,8 +163,8 @@ class ClinicServiceTests {
 
 		Pet pet = new Pet();
 		pet.setName("bowser");
-		Collection<PetType> types = this.types.findPetTypes();
-		pet.setType(EntityUtils.getById(types, PetType.class, 2));
+		Collection<PetType> petTypes = this.types.findPetTypes();
+		pet.setType(EntityUtils.getById(petTypes, PetType.class, 2));
 		pet.setBirthDate(LocalDate.now());
 		owner6.addPet(pet);
 		assertThat(owner6.getPets()).hasSize(found + 1);
@@ -203,9 +203,9 @@ class ClinicServiceTests {
 
 	@Test
 	void shouldFindVets() {
-		Collection<Vet> vets = this.vets.findAll();
+		Collection<Vet> allVets = this.vets.findAll();
 
-		Vet vet = EntityUtils.getById(vets, Vet.class, 3);
+		Vet vet = EntityUtils.getById(allVets, Vet.class, 3);
 		assertThat(vet.getLastName()).isEqualTo("Douglas");
 		assertThat(vet.getNrOfSpecialties()).isEqualTo(2);
 		assertThat(vet.getSpecialties().get(0).getName()).isEqualTo("dentistry");


### PR DESCRIPTION
## Summary

This PR addresses Task 2 Criterion 3: Avoid redundant coding (Unused code). It fixes SonarQube maintainability issues related to duplicated literals, unclear shadowed names, inconsistent constant naming, and tests that executed code without assertions.

## Changes

- Replaced the duplicated `"error"` flash attribute literal in `OwnerController` with a shared `ERROR_ATTRIBUTE` constant.
- Renamed shadowed or unclear variables/fields in `NamedEntity`, `Vets`, and `ClinicServiceTests`.
- Updated constants in `PetValidatorTests` to follow Java constant naming conventions.
- Added assertions to integration tests that previously called `vets.findAll()` without checking the result.

## Sustainability Justification

These changes improve maintainability by reducing duplicated values, making variable intent clearer, and strengthening test quality. The code is easier to read, safer to modify, and provides better regression protection for future changes.

## Testing

Ran related tests successfully:

- `PetValidatorTests`
- `PetClinicIntegrationTests`
- `ClinicServiceTests`