### PR TITLE
Fix: Handle invalid and out-of-range pagination in VetController and OwnerController

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.samples.petclinic.vet.VetRepository;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -52,8 +53,11 @@ class OwnerController {
 
 	private final OwnerRepository owners;
 
-	public OwnerController(OwnerRepository owners) {
+	private final VetRepository vetRepository;
+
+	public OwnerController(OwnerRepository owners, VetRepository vetRepository) {
 		this.owners = owners;
+		this.vetRepository = vetRepository;
 	}
 
 	@InitBinder
@@ -95,6 +99,18 @@ class OwnerController {
 	public String processFindForm(@RequestParam(defaultValue = "1") int page, Owner owner, BindingResult result,
 			Model model) {
 		// allow parameterless GET request for /owners to return all records
+		// calculate the total number of pages
+		int totalPages = (vetRepository.findAll().size() / 5) + 1;
+
+		// handling for the page<=0
+		if (page <= 0) {
+			page = 1;
+		}
+		// handling for the page>=totalPages
+		else if (page >= totalPages) {
+			page = totalPages;
+		}
+
 		String lastName = owner.getLastName();
 		if (lastName == null) {
 			lastName = ""; // empty string signifies broadest possible search

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -53,11 +53,8 @@ class OwnerController {
 
 	private final OwnerRepository owners;
 
-	private final VetRepository vetRepository;
-
-	public OwnerController(OwnerRepository owners, VetRepository vetRepository) {
+	public OwnerController(OwnerRepository owners) {
 		this.owners = owners;
-		this.vetRepository = vetRepository;
 	}
 
 	@InitBinder
@@ -100,7 +97,9 @@ class OwnerController {
 			Model model) {
 		// allow parameterless GET request for /owners to return all records
 		// calculate the total number of pages
-		int totalPages = (vetRepository.findAll().size() / 5) + 1;
+		int totalPages = owners
+			.findByLastNameStartingWith(owner.getLastName() != null ? owner.getLastName() : "", Pageable.unpaged())
+			.getTotalPages();
 
 		// handling for the page<=0
 		if (page <= 0) {

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -46,6 +46,17 @@ class VetController {
 		// Here we are returning an object of type 'Vets' rather than a collection of Vet
 		// objects so it is simpler for Object-Xml mapping
 		Vets vets = new Vets();
+		// calculate the total number of pages
+		int totalPages = (vetRepository.findAll().size() / 5) + 1;
+
+		// handling for the page<=0
+		if (page <= 0) {
+			page = 1;
+		}
+		// handling for the page>=totalPages
+		else if (page >= totalPages) {
+			page = totalPages;
+		}
 		Page<Vet> paginated = findPaginated(page);
 		vets.getVetList().addAll(paginated.toList());
 		return addPaginationModel(page, paginated, model);


### PR DESCRIPTION
Fixes #2379

### Summary
This PR resolves multiple pagination issues in VetController and OwnerController related to invalid and out-of-range page values.

### Issues Fixed
- Prevents 500 error when page=0 (invalid page index)
- Handles out-of-range page values (e.g., page=999)
- Ensures consistent pagination behavior and avoids empty or misleading UI states

### Changes Made
- Added validation to ensure page index is >= 1
- Adjusted logic to handle page values exceeding available data range
- Applied fixes in both VetController and OwnerController

### Testing
- Verified /vets.html?page=0 no longer throws 500 error
- Verified /vets.html?page=999 behaves correctly
- Verified /owners?page=0&lastName= works without error

### Note
This PR replaces the previous attempt with corrected implementation.