### PR TITLE
Fix invalid page parameter handling in VetController and OwnerController

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -100,6 +100,10 @@ class OwnerController {
 			lastName = ""; // empty string signifies broadest possible search
 		}
 
+		if (page < 1) {
+			return "redirect:/owners?page=1";
+		}
+
 		// find owners by last name
 		Page<Owner> ownersResults = findPaginatedForOwnersLastName(page, lastName);
 		if (ownersResults.isEmpty()) {

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -46,6 +46,9 @@ class VetController {
 		// Here we are returning an object of type 'Vets' rather than a collection of Vet
 		// objects so it is simpler for Object-Xml mapping
 		Vets vets = new Vets();
+		if (page < 1) {
+			return "redirect:/vets.html?page=1";
+		}
 		Page<Vet> paginated = findPaginated(page);
 		vets.getVetList().addAll(paginated.toList());
 		return addPaginationModel(page, paginated, model);

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -229,6 +229,13 @@ class OwnerControllerTests {
 	}
 
 	@Test
+	void processFindFormRedirectsInvalidPageToFirstPage() throws Exception {
+		mockMvc.perform(get("/owners?page=0"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/owners?page=1"));
+	}
+
+	@Test
 	void processUpdateOwnerFormWithIdMismatch() throws Exception {
 		int pathOwnerId = 1;
 

--- a/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
@@ -86,7 +86,13 @@ class VetControllerTests {
 			.andExpect(status().isOk())
 			.andExpect(model().attributeExists("listVets"))
 			.andExpect(view().name("vets/vetList"));
+	}
 
+	@Test
+	void showVetListRedirectsInvalidPageToFirstPage() throws Exception {
+		mockMvc.perform(get("/vets.html?page=0"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/vets.html?page=1"));
 	}
 
 	@Test


### PR DESCRIPTION
Summary
Fixes invalid pagination handling when `page=0` or negative values are passed to:
- `/vets.html`
- `/owners`

The controllers now redirect invalid page values to page 1 instead of causing server errors.

Changes
- Added validation for invalid page parameters
- Redirect invalid page requests to the first page
- Added controller tests for both VetController and OwnerController

Fixes #2379