### PR TITLE
Register native resource hints for nested db/{h2,mysql,postgres}/ scripts

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/PetClinicRuntimeHints.java
+++ b/src/main/java/org/springframework/samples/petclinic/PetClinicRuntimeHints.java
@@ -27,6 +27,7 @@ public class PetClinicRuntimeHints implements RuntimeHintsRegistrar {
 	@Override
 	public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
 		hints.resources().registerPattern("db/*"); // https://github.com/spring-projects/spring-boot/issues/32654
+		hints.resources().registerPattern("db/*/*"); // nested db/{h2,mysql,postgres}
 		hints.resources().registerPattern("messages/*");
 		hints.resources().registerPattern("mysql-default-conf");
 		hints.serialization().registerType(BaseEntity.class);


### PR DESCRIPTION
The existing hints.resources().registerPattern("db/*") only matches files directly under db/, but every SQL script in src/main/resources/db/ lives one level deeper (db/h2/schema.sql, db/postgres/schema.sql, db/mysql/schema.sql, plus their data.sql peers). A GraalVM native build therefore boots, answers /actuator/health 200, and then 500s every business endpoint because the schema was never bundled into the image (the missing-pattern manifests as a "table not found" at first JDBC use).

Adding registerPattern("db/*/*") covers the nested layout so all three profiles (h2, mysql, postgres) work in native mode. The existing top-level "db/*" line is kept untouched for backward compatibility.

Reproduced on GraalVM Community 25 with Spring Boot 4.0.x and the postgres profile.