### PR TITLE
Remove unused Vets object from VetController

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -43,11 +43,7 @@ class VetController {
 
 	@GetMapping("/vets.html")
 	public String showVetList(@RequestParam(defaultValue = "1") int page, Model model) {
-		// Here we are returning an object of type 'Vets' rather than a collection of Vet
-		// objects so it is simpler for Object-Xml mapping
-		Vets vets = new Vets();
 		Page<Vet> paginated = findPaginated(page);
-		vets.getVetList().addAll(paginated.toList());
 		return addPaginationModel(page, paginated, model);
 	}
 


### PR DESCRIPTION
## Summary

- remove the unused `Vets` object from `VetController#showVetList`
- preserve existing license header, author tags, and JSON endpoint behavior

## Related issue

Closes #2333

## Testing

- `./mvnw -q -Dtest=VetControllerTests test`
- `./mvnw -q test`
- `git diff --check`