### PR TITLE
Refactor: Fix Magic Number and Sanitize Input for Owner Search (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,4 @@ The Spring PetClinic sample application is released under version 2.0 of the [Ap
 * Eren Özel
 * Mehmet Zeki Aktaş
 * Zeki Emir Büyükçakır
+* Efe Beyaz

--- a/README.md
+++ b/README.md
@@ -179,3 +179,4 @@ The Spring PetClinic sample application is released under version 2.0 of the [Ap
 * Mehmet Zeki Aktaş
 * Zeki Emir Büyükçakır
 * Efe Beyaz
+* Alp Demir

--- a/README.md
+++ b/README.md
@@ -179,4 +179,4 @@ The Spring PetClinic sample application is released under version 2.0 of the [Ap
 * Mehmet Zeki Aktaş
 * Zeki Emir Büyükçakır
 * Efe Beyaz
-* Alp Demir
+* Alp Demir 

--- a/README.md
+++ b/README.md
@@ -180,3 +180,4 @@ The Spring PetClinic sample application is released under version 2.0 of the [Ap
 * Zeki Emir Büyükçakır
 * Efe Beyaz
 * Alp Demir 
+|--------------------------|

--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ The Spring PetClinic sample application is released under version 2.0 of the [Ap
 ## Team Members
 * Eren Özel
 * Mehmet Zeki Aktaş
-
+* Zeki Emir Büyükçakır

--- a/README.md
+++ b/README.md
@@ -172,3 +172,7 @@ For additional details, please refer to the blog post [Hello DCO, Goodbye CLA: S
 ## License
 
 The Spring PetClinic sample application is released under version 2.0 of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0).
+
+
+## Team Members
+* Eren Özel

--- a/README.md
+++ b/README.md
@@ -176,3 +176,5 @@ The Spring PetClinic sample application is released under version 2.0 of the [Ap
 
 ## Team Members
 * Eren Özel
+* Mehmet Zeki Aktaş
+

--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -126,6 +126,7 @@ public class Owner extends Person {
 		return null;
 	}
 
+
 	/**
 	 * Return the Pet with the given name, or null if none found for this Owner.
 	 * @param name to test
@@ -133,15 +134,11 @@ public class Owner extends Person {
 	 * @return the Pet with the given name, or null if no such Pet exists for this Owner
 	 */
 	public Pet getPet(String name, boolean ignoreNew) {
-		for (Pet pet : getPets()) {
-			String compName = pet.getName();
-			if (compName != null && compName.equalsIgnoreCase(name)) {
-				if (!ignoreNew || !pet.isNew()) {
-					return pet;
-				}
-			}
-		}
-		return null;
+		return getPets().stream()
+			.filter(pet -> pet.getName() != null && pet.getName().equalsIgnoreCase(name))
+			.filter(pet -> !ignoreNew || !pet.isNew())
+			.findFirst()
+			.orElse(null);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -126,7 +126,6 @@ public class Owner extends Person {
 		return null;
 	}
 
-
 	/**
 	 * Return the Pet with the given name, or null if none found for this Owner.
 	 * @param name to test

--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -31,8 +31,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 /**
  * Simple JavaBean domain object representing an owner.
@@ -102,7 +102,6 @@ public class Owner extends Person {
 
 	/**
 	 * Return the Pet with the given name, or null if none found for this Owner.
-	 *
 	 * @param name to test
 	 * @return the Pet with the given name, or null if no such Pet exists for this Owner
 	 */
@@ -112,7 +111,6 @@ public class Owner extends Person {
 
 	/**
 	 * Return the Pet with the given id, or null if none found for this Owner.
-	 *
 	 * @param id to test
 	 * @return the Pet with the given id, or null if no such Pet exists for this Owner
 	 */
@@ -128,11 +126,9 @@ public class Owner extends Person {
 		return null;
 	}
 
-
 	/**
 	 * Return the Pet with the given name, or null if none found for this Owner.
-	 *
-	 * @param name      to test
+	 * @param name to test
 	 * @param ignoreNew whether to ignore new pets (pets that are not saved yet)
 	 * @return the Pet with the given name, or null if no such Pet exists for this Owner
 	 */
@@ -146,12 +142,18 @@ public class Owner extends Person {
 
 	@Override
 	public String toString() {
-		return new ToStringCreator(this).append("id", this.getId()).append("new", this.isNew()).append("lastName", this.getLastName()).append("firstName", this.getFirstName()).append("address", this.address).append("city", this.city).append("telephone", this.telephone).toString();
+		return new ToStringCreator(this).append("id", this.getId())
+			.append("new", this.isNew())
+			.append("lastName", this.getLastName())
+			.append("firstName", this.getFirstName())
+			.append("address", this.address)
+			.append("city", this.city)
+			.append("telephone", this.telephone)
+			.toString();
 	}
 
 	/**
 	 * Adds the given {@link Visit} to the {@link Pet} with the given identifier.
-	 *
 	 * @param petId the identifier of the {@link Pet}, must not be {@literal null}.
 	 * @param visit the visit to add, must not be {@literal null}.
 	 */

--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -102,6 +102,7 @@ public class Owner extends Person {
 
 	/**
 	 * Return the Pet with the given name, or null if none found for this Owner.
+	 *
 	 * @param name to test
 	 * @return the Pet with the given name, or null if no such Pet exists for this Owner
 	 */
@@ -111,6 +112,7 @@ public class Owner extends Person {
 
 	/**
 	 * Return the Pet with the given id, or null if none found for this Owner.
+	 *
 	 * @param id to test
 	 * @return the Pet with the given id, or null if no such Pet exists for this Owner
 	 */
@@ -128,7 +130,8 @@ public class Owner extends Person {
 
 	/**
 	 * Return the Pet with the given name, or null if none found for this Owner.
-	 * @param name to test
+	 *
+	 * @param name      to test
 	 * @param ignoreNew whether to ignore new pets (pets that are not saved yet)
 	 * @return the Pet with the given name, or null if no such Pet exists for this Owner
 	 */
@@ -146,18 +149,12 @@ public class Owner extends Person {
 
 	@Override
 	public String toString() {
-		return new ToStringCreator(this).append("id", this.getId())
-			.append("new", this.isNew())
-			.append("lastName", this.getLastName())
-			.append("firstName", this.getFirstName())
-			.append("address", this.address)
-			.append("city", this.city)
-			.append("telephone", this.telephone)
-			.toString();
+		return new ToStringCreator(this).append("id", this.getId()).append("new", this.isNew()).append("lastName", this.getLastName()).append("firstName", this.getFirstName()).append("address", this.address).append("city", this.city).append("telephone", this.telephone).toString();
 	}
 
 	/**
 	 * Adds the given {@link Visit} to the {@link Pet} with the given identifier.
+	 *
 	 * @param petId the identifier of the {@link Pet}, must not be {@literal null}.
 	 * @param visit the visit to add, must not be {@literal null}.
 	 */

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -50,6 +50,14 @@ class OwnerController {
 
 	private static final String VIEWS_OWNER_CREATE_OR_UPDATE_FORM = "owners/createOrUpdateOwnerForm";
 
+	/**
+	 * Default number of owner records displayed per page. Extracting this magic number
+	 * into a named constant improves maintainability, allowing future application-wide
+	 * page size adjustments from a single location without altering the core search
+	 * logic.
+	 */
+	private static final int DEFAULT_PAGE_SIZE = 5;
+
 	private final OwnerRepository owners;
 
 	public OwnerController(OwnerRepository owners) {
@@ -91,6 +99,17 @@ class OwnerController {
 		return "owners/findOwners";
 	}
 
+	/**
+	 * Processes the form for finding owners. Sanitizes the user search input by trimming
+	 * leading and trailing whitespaces from the last name parameter to prevent accidental
+	 * "no results found" errors, ensuring application robustness and clean code
+	 * standards. Handles null inputs gracefully to avoid potential NullPointerExceptions.
+	 * @param page the current page number
+	 * @param owner the owner domain object backing the form
+	 * @param result the binding results for error handling
+	 * @param model the UI model
+	 * @return the view name or redirect URL
+	 */
 	@GetMapping("/owners")
 	public String processFindForm(@RequestParam(defaultValue = "1") int page, Owner owner, BindingResult result,
 			Model model) {
@@ -99,7 +118,10 @@ class OwnerController {
 		if (lastName == null) {
 			lastName = ""; // empty string signifies broadest possible search
 		}
+		else {
+			lastName = lastName.trim(); // Sanitize input by stripping white spaces
 
+		}
 		// find owners by last name
 		Page<Owner> ownersResults = findPaginatedForOwnersLastName(page, lastName);
 		if (ownersResults.isEmpty()) {
@@ -127,9 +149,15 @@ class OwnerController {
 		return "owners/ownersList";
 	}
 
+	/**
+	 * Fetches a paginated list of owners based on the sanitized last name. Utilizes the
+	 * centralized configuration constant for page size to build the page request.
+	 * @param page the current page number (1-indexed)
+	 * @param lastname the sanitized string to search for
+	 * @return a page of matching owners
+	 */
 	private Page<Owner> findPaginatedForOwnersLastName(int page, String lastname) {
-		int pageSize = 5;
-		Pageable pageable = PageRequest.of(page - 1, pageSize);
+		Pageable pageable = PageRequest.of(page - 1, DEFAULT_PAGE_SIZE);
 		return owners.findByLastNameStartingWith(lastname, pageable);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -66,22 +66,19 @@ class PetController {
 	@ModelAttribute("owner")
 	public Owner findOwner(@PathVariable("ownerId") int ownerId) {
 		Optional<Owner> optionalOwner = this.owners.findById(ownerId);
-		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
-				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
+		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException("Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
 		return owner;
 	}
 
 	@ModelAttribute("pet")
-	public Pet findPet(@PathVariable("ownerId") int ownerId,
-			@PathVariable(name = "petId", required = false) Integer petId) {
+	public Pet findPet(@PathVariable("ownerId") int ownerId, @PathVariable(name = "petId", required = false) Integer petId) {
 
 		if (petId == null) {
 			return new Pet();
 		}
 
 		Optional<Owner> optionalOwner = this.owners.findById(ownerId);
-		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
-				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
+		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException("Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
 		return owner.getPet(petId);
 	}
 
@@ -104,8 +101,7 @@ class PetController {
 	}
 
 	@PostMapping("/pets/new")
-	public String processCreationForm(Owner owner, @Valid Pet pet, BindingResult result,
-			RedirectAttributes redirectAttributes) {
+	public String processCreationForm(Owner owner, @Valid Pet pet, BindingResult result, RedirectAttributes redirectAttributes) {
 
 		if (StringUtils.hasText(pet.getName()) && pet.isNew() && owner.getPet(pet.getName(), true) != null) {
 			result.rejectValue("name", "duplicate", "already exists");
@@ -129,8 +125,7 @@ class PetController {
 	}
 
 	@PostMapping("/pets/{petId}/edit")
-	public String processUpdateForm(Owner owner, @Valid Pet pet, BindingResult result,
-			RedirectAttributes redirectAttributes) {
+	public String processUpdateForm(Owner owner, @Valid Pet pet, BindingResult result, RedirectAttributes redirectAttributes) {
 
 		String petName = pet.getName();
 
@@ -155,8 +150,9 @@ class PetController {
 
 	/**
 	 * Updates the pet details if it exists or adds a new pet to the owner.
+	 *
 	 * @param owner The owner of the pet
-	 * @param pet The pet with updated details
+	 * @param pet   The pet with updated details
 	 */
 	private void updatePetDetails(Owner owner, Pet pet) {
 		Integer id = pet.getId();
@@ -167,17 +163,18 @@ class PetController {
 			existingPet.setName(pet.getName());
 			existingPet.setBirthDate(pet.getBirthDate());
 			existingPet.setType(pet.getType());
-		}
-		else {
+		} else {
 			owner.addPet(pet);
 		}
 		this.owners.save(owner);
 	}
+
 	/**
 	 * Validates that the pet's birthdate is not in the future.
 	 * If the date is invalid, an error is added to the BindingResult.
-	 * * @param pet    The pet object to validate.
-	 * @param result The BindingResult to hold validation errors.
+	 *
+	 * @param pet    the pet object to validate
+	 * @param result the BindingResult to hold validation errors
 	 */
 	private void validatePetBirthDate(Pet pet, BindingResult result) {
 		if (pet.getBirthDate() != null && pet.getBirthDate().isAfter(LocalDate.now())) {

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -111,10 +111,7 @@ class PetController {
 			result.rejectValue("name", "duplicate", "already exists");
 		}
 
-		LocalDate currentDate = LocalDate.now();
-		if (pet.getBirthDate() != null && pet.getBirthDate().isAfter(currentDate)) {
-			result.rejectValue("birthDate", "typeMismatch.birthDate");
-		}
+		validatePetBirthDate(pet, result);
 
 		if (result.hasErrors()) {
 			return VIEWS_PETS_CREATE_OR_UPDATE_FORM;
@@ -145,10 +142,7 @@ class PetController {
 			}
 		}
 
-		LocalDate currentDate = LocalDate.now();
-		if (pet.getBirthDate() != null && pet.getBirthDate().isAfter(currentDate)) {
-			result.rejectValue("birthDate", "typeMismatch.birthDate");
-		}
+		validatePetBirthDate(pet, result);
 
 		if (result.hasErrors()) {
 			return VIEWS_PETS_CREATE_OR_UPDATE_FORM;
@@ -179,5 +173,15 @@ class PetController {
 		}
 		this.owners.save(owner);
 	}
-
+	/**
+	 * Validates that the pet's birthdate is not in the future.
+	 * If the date is invalid, an error is added to the BindingResult.
+	 * * @param pet    The pet object to validate.
+	 * @param result The BindingResult to hold validation errors.
+	 */
+	private void validatePetBirthDate(Pet pet, BindingResult result) {
+		if (pet.getBirthDate() != null && pet.getBirthDate().isAfter(LocalDate.now())) {
+			result.rejectValue("birthDate", "typeMismatch.birthDate");
+		}
+	}
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -66,19 +66,22 @@ class PetController {
 	@ModelAttribute("owner")
 	public Owner findOwner(@PathVariable("ownerId") int ownerId) {
 		Optional<Owner> optionalOwner = this.owners.findById(ownerId);
-		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException("Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
+		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
+				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
 		return owner;
 	}
 
 	@ModelAttribute("pet")
-	public Pet findPet(@PathVariable("ownerId") int ownerId, @PathVariable(name = "petId", required = false) Integer petId) {
+	public Pet findPet(@PathVariable("ownerId") int ownerId,
+			@PathVariable(name = "petId", required = false) Integer petId) {
 
 		if (petId == null) {
 			return new Pet();
 		}
 
 		Optional<Owner> optionalOwner = this.owners.findById(ownerId);
-		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException("Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
+		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
+				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
 		return owner.getPet(petId);
 	}
 
@@ -101,7 +104,8 @@ class PetController {
 	}
 
 	@PostMapping("/pets/new")
-	public String processCreationForm(Owner owner, @Valid Pet pet, BindingResult result, RedirectAttributes redirectAttributes) {
+	public String processCreationForm(Owner owner, @Valid Pet pet, BindingResult result,
+			RedirectAttributes redirectAttributes) {
 
 		if (StringUtils.hasText(pet.getName()) && pet.isNew() && owner.getPet(pet.getName(), true) != null) {
 			result.rejectValue("name", "duplicate", "already exists");
@@ -125,7 +129,8 @@ class PetController {
 	}
 
 	@PostMapping("/pets/{petId}/edit")
-	public String processUpdateForm(Owner owner, @Valid Pet pet, BindingResult result, RedirectAttributes redirectAttributes) {
+	public String processUpdateForm(Owner owner, @Valid Pet pet, BindingResult result,
+			RedirectAttributes redirectAttributes) {
 
 		String petName = pet.getName();
 
@@ -150,9 +155,8 @@ class PetController {
 
 	/**
 	 * Updates the pet details if it exists or adds a new pet to the owner.
-	 *
 	 * @param owner The owner of the pet
-	 * @param pet   The pet with updated details
+	 * @param pet The pet with updated details
 	 */
 	private void updatePetDetails(Owner owner, Pet pet) {
 		Integer id = pet.getId();
@@ -163,17 +167,17 @@ class PetController {
 			existingPet.setName(pet.getName());
 			existingPet.setBirthDate(pet.getBirthDate());
 			existingPet.setType(pet.getType());
-		} else {
+		}
+		else {
 			owner.addPet(pet);
 		}
 		this.owners.save(owner);
 	}
 
 	/**
-	 * Validates that the pet's birthdate is not in the future.
-	 * If the date is invalid, an error is added to the BindingResult.
-	 *
-	 * @param pet    the pet object to validate
+	 * Validates that the pet's birthdate is not in the future. If the date is invalid, an
+	 * error is added to the BindingResult.
+	 * @param pet the pet object to validate
 	 * @param result the BindingResult to hold validation errors
 	 */
 	private void validatePetBirthDate(Pet pet, BindingResult result) {
@@ -181,4 +185,5 @@ class PetController {
 			result.rejectValue("birthDate", "typeMismatch.birthDate");
 		}
 	}
+
 }

--- a/src/main/java/org/springframework/samples/petclinic/system/CrashController.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/CrashController.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.samples.petclinic.system;
 
 import org.springframework.stereotype.Controller;

--- a/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
@@ -75,8 +75,6 @@ public class Vet extends Person {
 		return getSpecialtiesInternal() != null ? getSpecialtiesInternal().size() : 0;
 	}
 
-
-
 	public void addSpecialty(Specialty specialty) {
 		getSpecialtiesInternal().add(specialty);
 	}

--- a/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
@@ -15,13 +15,15 @@
  */
 package org.springframework.samples.petclinic.vet;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import java.util.Comparator;
 
-import org.springframework.beans.support.MutableSortDefinition;
-import org.springframework.beans.support.PropertyComparator;
-import java.util.Collections;
 import org.springframework.samples.petclinic.model.NamedEntity;
 import org.springframework.samples.petclinic.model.Person;
 
@@ -60,7 +62,8 @@ public class Vet extends Person {
 	@XmlElement
 	public List<Specialty> getSpecialties() {
 		List<Specialty> sortedSpecs = new ArrayList<>(getSpecialtiesInternal());
-		PropertyComparator.sort(sortedSpecs, new MutableSortDefinition("name", true, true));
+
+		sortedSpecs.sort(Comparator.comparing(Specialty::getName));
 		return Collections.unmodifiableList(sortedSpecs);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
@@ -15,11 +15,10 @@
  */
 package org.springframework.samples.petclinic.vet;
 
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
+
+
 
 import org.springframework.samples.petclinic.model.NamedEntity;
 import org.springframework.samples.petclinic.model.Person;
@@ -58,14 +57,20 @@ public class Vet extends Person {
 
 	@XmlElement
 	public List<Specialty> getSpecialties() {
-		return getSpecialtiesInternal().stream()
-			.sorted(Comparator.comparing(NamedEntity::getName))
-			.collect(Collectors.toList());
+		List<Specialty> sortedSpecs = new ArrayList<>(getSpecialtiesInternal());
+		PropertyComparator.sort(sortedSpecs, new MutableSortDefinition("name", true, true));
+		return Collections.unmodifiableList(sortedSpecs);
+	}
+
+	public boolean hasSpecialties() {
+		return getSpecialtiesInternal() != null && !getSpecialtiesInternal().isEmpty();
 	}
 
 	public int getNrOfSpecialties() {
-		return getSpecialtiesInternal().size();
+		return getSpecialtiesInternal() != null ? getSpecialtiesInternal().size() : 0;
 	}
+
+
 
 	public void addSpecialty(Specialty specialty) {
 		getSpecialtiesInternal().add(specialty);

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 class VetController {
 
 	private final VetRepository vetRepository;
-	private VetRepository vets;
+
 
 	public VetController(VetRepository vetRepository) {
 		this.vetRepository = vetRepository;
@@ -50,7 +50,7 @@ class VetController {
 		Page<Vet> paginated = findPaginated(page);
 		vets.getVetList().addAll(paginated.toList());
 		Vets allVets = new Vets();
-		allVets.getVetList().addAll(this.vets.findAll());
+		allVets.getVetList().addAll(this.vetRepository.findAll());
 		model.addAttribute("generalPracticeCount", allVets.getGeneralPracticeCount());
 		model.addAttribute("specialistCount", allVets.getSpecialistCount());
 		model.addAttribute("totalVets", allVets.getGeneralPracticeCount() + allVets.getSpecialistCount());

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -37,7 +37,6 @@ class VetController {
 
 	private final VetRepository vetRepository;
 
-
 	public VetController(VetRepository vetRepository) {
 		this.vetRepository = vetRepository;
 	}

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -36,6 +36,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 class VetController {
 
 	private final VetRepository vetRepository;
+	private VetRepository vets;
 
 	public VetController(VetRepository vetRepository) {
 		this.vetRepository = vetRepository;
@@ -48,6 +49,11 @@ class VetController {
 		Vets vets = new Vets();
 		Page<Vet> paginated = findPaginated(page);
 		vets.getVetList().addAll(paginated.toList());
+		Vets allVets = new Vets();
+		allVets.getVetList().addAll(this.vets.findAll());
+		model.addAttribute("generalPracticeCount", allVets.getGeneralPracticeCount());
+		model.addAttribute("specialistCount", allVets.getSpecialistCount());
+		model.addAttribute("totalVets", allVets.getGeneralPracticeCount() + allVets.getSpecialistCount());
 		return addPaginationModel(page, paginated, model);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/vet/Vets.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Vets.java
@@ -41,12 +41,14 @@ public class Vets {
 	}
 
 	public long getGeneralPracticeCount() {
-		if (this.vets == null) return 0;
+		if (this.vets == null)
+			return 0;
 		return this.vets.stream().filter(vet -> !vet.hasSpecialties()).count();
 	}
 
 	public long getSpecialistCount() {
-		if (this.vets == null) return 0;
+		if (this.vets == null)
+			return 0;
 		return this.vets.stream().filter(Vet::hasSpecialties).count();
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/vet/Vets.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Vets.java
@@ -40,4 +40,14 @@ public class Vets {
 		return vets;
 	}
 
+	public long getGeneralPracticeCount() {
+		if (this.vets == null) return 0;
+		return this.vets.stream().filter(vet -> !vet.hasSpecialties()).count();
+	}
+
+	public long getSpecialistCount() {
+		if (this.vets == null) return 0;
+		return this.vets.stream().filter(Vet::hasSpecialties).count();
+	}
+
 }

--- a/src/main/resources/templates/vets/vetList.html
+++ b/src/main/resources/templates/vets/vetList.html
@@ -17,12 +17,26 @@
       <tr th:each="vet : ${listVets}">
         <td th:text="${vet.firstName + ' ' + vet.lastName}"></td>
         <td>
-          <span th:each="specialty : ${vet.specialties}" th:text="${specialty.name + ' '}" /> <span
-            th:if="${vet.nrOfSpecialties == 0}" th:text="#{none}">none</span>
+          <span th:if="${vet.nrOfSpecialties == 0}" class="text-muted">General Practice</span>
+          <span th:unless="${vet.nrOfSpecialties == 0}">
+                    <span th:each="specialty : ${vet.specialties}"
+                          th:text="${specialty.name} + ' '"
+                          class="badge bg-info text-dark"></span>
+                </span>
         </td>
       </tr>
     </tbody>
   </table>
+  <div class="row mt-4 mb-4 p-3 bg-light rounded">
+    <div class="col-md-12">
+      <h5>Clinic Staff Summary</h5>
+      <ul class="list-unstyled">
+        <li><strong>General Practitioners:</strong> <span th:text="${generalPracticeCount}">0</span></li>
+        <li><strong>Specialists:</strong> <span th:text="${specialistCount}">0</span></li>
+        <li><strong>Total:</strong> <span th:text="${totalVets}">0</span></li>
+      </ul>
+    </div>
+  </div>
   <div th:if="${totalPages > 1}">
     <span th:text="#{pages}">Pages:</span>
     <span>[</span>

--- a/src/main/resources/templates/vets/vetList.html
+++ b/src/main/resources/templates/vets/vetList.html
@@ -17,7 +17,7 @@
       <tr th:each="vet : ${listVets}">
         <td th:text="${vet.firstName + ' ' + vet.lastName}"></td>
         <td>
-          <span th:if="${vet.nrOfSpecialties == 0}" class="text-muted">General Practice</span>
+          <span th:if="${vet.nrOfSpecialties == 0}" class="text-muted" th:text="'General Practice'"></span>
           <span th:unless="${vet.nrOfSpecialties == 0}">
                     <span th:each="specialty : ${vet.specialties}"
                           th:text="${specialty.name} + ' '"
@@ -29,13 +29,14 @@
   </table>
   <div class="row mt-4 mb-4 p-3 bg-light rounded">
     <div class="col-md-12">
-      <h5>Clinic Staff Summary</h5>
+      <h5 th:text="'Clinic Staff Summary'"></h5>
       <ul class="list-unstyled">
-        <li><strong>General Practitioners:</strong> <span th:text="${generalPracticeCount}">0</span></li>
-        <li><strong>Specialists:</strong> <span th:text="${specialistCount}">0</span></li>
-        <li><strong>Total:</strong> <span th:text="${totalVets}">0</span></li>
+        <li><strong th:text="'General Practitioners:'"></strong> <span th:text="${generalPracticeCount}">0</span></li>
+        <li><strong th:text="'Specialists:'"></strong> <span th:text="${specialistCount}">0</span></li>
+        <li><strong th:text="'Total:'"></strong> <span th:text="${totalVets}">0</span></li>
       </ul>
     </div>
+  </div>
   </div>
   <div th:if="${totalPages > 1}">
     <span th:text="#{pages}">Pages:</span>

--- a/src/test/java/org/springframework/samples/petclinic/vet/VetTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/vet/VetTests.java
@@ -17,6 +17,7 @@ package org.springframework.samples.petclinic.vet;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.util.SerializationUtils;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +37,15 @@ class VetTests {
 		assertThat(other.getFirstName()).isEqualTo(vet.getFirstName());
 		assertThat(other.getLastName()).isEqualTo(vet.getLastName());
 		assertThat(other.getId()).isEqualTo(vet.getId());
+	}
+	@Test
+	void testHasSpecialtiesAndCount() {
+		Vet vet = new Vet();
+		assertThat(vet.hasSpecialties()).isFalse();
+		Specialty s = new Specialty();
+		s.setName("dentistry");
+		vet.addSpecialty(s);
+		assertThat(vet.hasSpecialties()).isTrue();
 	}
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/vet/VetTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/vet/VetTests.java
@@ -15,11 +15,11 @@
  */
 package org.springframework.samples.petclinic.vet;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.util.SerializationUtils;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.SerializationUtils;
 
 /**
  * @author Dave Syer
@@ -38,6 +38,7 @@ class VetTests {
 		assertThat(other.getLastName()).isEqualTo(vet.getLastName());
 		assertThat(other.getId()).isEqualTo(vet.getId());
 	}
+
 	@Test
 	void testHasSpecialtiesAndCount() {
 		Vet vet = new Vet();


### PR DESCRIPTION
## What was done?
- Resolved **Issue #4** regarding `OwnerController` code smell and robustness.
- Extracted the hardcoded magic number `5` used for pagination into a centralized configuration constant.
- Added input sanitization to the owner search form to trim unintended whitespaces and gracefully handle null values.

## Solution
1. **Magic Number Elimination:** Introduced `private static final int DEFAULT_PAGE_SIZE = 5;` at the class level and refactored `findPaginatedForOwnersLastName` to utilize this named constant.
2. **Input Sanitization:** Updated `processFindForm` method to include a `.trim()` safe-check on the `lastName` parameter to prevent accidental "no results found" errors caused by leading/trailing spaces.
3. **Documentation:** Added professional JavaDoc comments explaining the maintainability and robustness benefits of these changes.

Closes #4