### PR TITLE
Remove unused Vets object from showVetList in VetController

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -43,11 +43,7 @@ class VetController {
 
 	@GetMapping("/vets.html")
 	public String showVetList(@RequestParam(defaultValue = "1") int page, Model model) {
-		// Here we are returning an object of type 'Vets' rather than a collection of Vet
-		// objects so it is simpler for Object-Xml mapping
-		Vets vets = new Vets();
 		Page<Vet> paginated = findPaginated(page);
-		vets.getVetList().addAll(paginated.toList());
 		return addPaginationModel(page, paginated, model);
 	}
 


### PR DESCRIPTION
## What Changed

Removed 4 lines of dead code in `VetController.java` (`showVetList` method):

- `Vets vets = new Vets();` — instantiated but never used
- `vets.getVetList().addAll(paginated.toList());` — populated but never consumed
- Misleading comment about "Object-Xml mapping" (that applies to `showResourcesVetList()`, not `showVetList()`)

The `addPaginationModel()` method already handles everything by reading `paginated.getContent()` and adding it as `listVets` to the model. The Thymeleaf template `vets/vetList.html` iterates `${listVets}` — no `Vets` wrapper is needed.

## Verification

| Command | Result |
|---|---|
| `./gradlew compileJava` | BUILD SUCCESSFUL |
| `./gradlew test --tests org.springframework.samples.petclinic.vet.* --tests org.springframework.samples.petclinic.service.* --tests org.springframework.samples.petclinic.PetClinicIntegrationTests` | BUILD SUCCESSFUL, all tests passed |

## Risks

None — this is purely dead code removal. The `Vets` object was never added to the model, so removing it has zero runtime impact.
