### PR TITLE
Remove unused Vets object from showVetList

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -45,9 +45,7 @@ class VetController {
 	public String showVetList(@RequestParam(defaultValue = "1") int page, Model model) {
 		// Here we are returning an object of type 'Vets' rather than a collection of Vet
 		// objects so it is simpler for Object-Xml mapping
-		Vets vets = new Vets();
 		Page<Vet> paginated = findPaginated(page);
-		vets.getVetList().addAll(paginated.toList());
 		return addPaginationModel(page, paginated, model);
 	}
 


### PR DESCRIPTION
## Summary

Removed the unused `Vets` object from `VetController#showVetList()`.

The object was created and populated but never added to the model or otherwise used. The page already relies on the paginated `listVets` model attribute provided by `addPaginationModel()`.

## Validation

* Application starts successfully
* `/vets.html` displays the vet list correctly
* Maven tests pass successfully
