### PR TITLE
Remove unused Vets object from VetController

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -43,14 +43,9 @@ class VetController {
 
 	@GetMapping("/vets.html")
 	public String showVetList(@RequestParam(defaultValue = "1") int page, Model model) {
-		// Here we are returning an object of type 'Vets' rather than a collection of Vet
-		// objects so it is simpler for Object-Xml mapping
-		Vets vets = new Vets();
 		Page<Vet> paginated = findPaginated(page);
-		vets.getVetList().addAll(paginated.toList());
 		return addPaginationModel(page, paginated, model);
 	}
-
 	private String addPaginationModel(int page, Page<Vet> paginated, Model model) {
 		List<Vet> listVets = paginated.getContent();
 		model.addAttribute("currentPage", page);


### PR DESCRIPTION
The method created and populated a Vets instance using the paginated results, but the object was never added to the model, returned, or otherwise used.

Vets vets = new Vets();
Page<Vet> paginated = findPaginated(page);
vets.getVetList().addAll(paginated.toList());
return addPaginationModel(page, paginated, model);

Since the populated Vets object has no effect on the method's behavior, this change removes the dead code and simplifies the implementation.

Testing
Ran the application locally.
Verified that /vets.html continues to display veterinarians correctly.
Verified that pagination continues to function as expected.
No behavioral changes observed.