### PR TITLE
test: add owner integration automation

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/integration/OwnerControllerBindingTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/integration/OwnerControllerBindingTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.owner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.aot.DisabledInAotMode;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Controller binding integration coverage for reviewed Owner scenarios.
+ */
+@WebMvcTest(OwnerController.class)
+@DisabledInNativeImage
+@DisabledInAotMode
+class OwnerControllerBindingTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private OwnerRepository owners;
+
+	@Test
+	void int007OwnerUpdateIgnoresMassAssignmentAttemptsForIds() throws Exception {
+		Owner owner = ownerWithPet(1, 7);
+		given(this.owners.findById(1)).willReturn(Optional.of(owner));
+
+		this.mockMvc
+			.perform(post("/owners/{ownerId}/edit", 1).param("id", "99")
+				.param("pets[0].id", "88")
+				.param("firstName", "Changed")
+				.param("lastName", "Owner")
+				.param("address", "500 Changed Street")
+				.param("city", "Middleton")
+				.param("telephone", "6085551111"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(view().name("redirect:/owners/{ownerId}"));
+
+		ArgumentCaptor<Owner> captor = ArgumentCaptor.forClass(Owner.class);
+		verify(this.owners).save(captor.capture());
+		Owner saved = captor.getValue();
+		assertThat(saved.getId()).isEqualTo(1);
+		assertThat(saved.getPets().get(0).getId()).isEqualTo(7);
+		assertThat(saved.getFirstName()).isEqualTo("Changed");
+		assertThat(saved.getAddress()).isEqualTo("500 Changed Street");
+	}
+
+	@Test
+	void int008MismatchedOwnerModelIdDoesNotSaveAndRedirectsBackToEdit() throws Exception {
+		Owner owner = ownerWithPet(2, 7);
+		given(this.owners.findById(1)).willReturn(Optional.of(owner));
+
+		this.mockMvc.perform(post("/owners/{ownerId}/edit", 1).flashAttr("owner", owner))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/owners/1/edit"))
+			.andExpect(flash().attributeExists("error"));
+
+		verify(this.owners, never()).save(any(Owner.class));
+	}
+
+	private Owner ownerWithPet(int ownerId, int petId) {
+		Owner owner = new Owner();
+		owner.setId(ownerId);
+		owner.setFirstName("Original");
+		owner.setLastName("Owner");
+		owner.setAddress("100 Original Street");
+		owner.setCity("Madison");
+		owner.setTelephone("6085550000");
+		Pet pet = new Pet();
+		pet.setId(petId);
+		pet.setName("Max");
+		owner.getPets().add(pet);
+		return owner;
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/owner/integration/OwnerRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/integration/OwnerRepositoryIntegrationTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.owner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+/**
+ * Owner repository integration coverage for reviewed scenarios.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class OwnerRepositoryIntegrationTests {
+
+	@Autowired
+	private OwnerRepository owners;
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Test
+	void int002BlankLastNameSearchSupportsDeterministicPagination() {
+		Page<Owner> firstPage = this.owners.findByLastNameStartingWith("", PageRequest.of(0, 5));
+		Page<Owner> secondPage = this.owners.findByLastNameStartingWith("", PageRequest.of(1, 5));
+
+		assertThat(firstPage.getContent()).hasSize(5);
+		assertThat(secondPage.getContent()).hasSize(5);
+		assertThat(firstPage.getTotalElements()).isEqualTo(10);
+		assertThat(secondPage.getTotalElements()).isEqualTo(10);
+		assertThat(firstPage.getContent()).extracting(Owner::getId)
+			.doesNotContainAnyElementsOf(secondPage.getContent().stream().map(Owner::getId).toList());
+	}
+
+	@Test
+	void int003SavingNewOwnerGeneratesIdAndPersistsContactFields() {
+		Owner owner = new Owner();
+		owner.setFirstName("Sam");
+		owner.setLastName("Roundtrip");
+		owner.setAddress("4 Evans Street");
+		owner.setCity("Wollongong");
+		owner.setTelephone("4444444444");
+
+		Owner saved = this.owners.save(owner);
+		this.entityManager.flush();
+		this.entityManager.clear();
+
+		Owner reloaded = this.owners.findById(saved.getId()).orElseThrow();
+		assertThat(reloaded.getId()).isNotNull();
+		assertThat(reloaded.getFirstName()).isEqualTo("Sam");
+		assertThat(reloaded.getLastName()).isEqualTo("Roundtrip");
+		assertThat(reloaded.getAddress()).isEqualTo("4 Evans Street");
+		assertThat(reloaded.getCity()).isEqualTo("Wollongong");
+		assertThat(reloaded.getTelephone()).isEqualTo("4444444444");
+	}
+
+	@Test
+	void int004UpdatingOwnerContactFieldsPreservesExistingPetRelationships() {
+		Owner owner = this.owners.findById(6).orElseThrow();
+		List<Integer> petIds = owner.getPets().stream().map(Pet::getId).toList();
+
+		owner.setAddress("400 Updated Lane");
+		owner.setCity("Middleton");
+		owner.setTelephone("6085559999");
+		this.owners.save(owner);
+		this.entityManager.flush();
+		this.entityManager.clear();
+
+		Owner reloaded = this.owners.findById(6).orElseThrow();
+		assertThat(reloaded.getAddress()).isEqualTo("400 Updated Lane");
+		assertThat(reloaded.getCity()).isEqualTo("Middleton");
+		assertThat(reloaded.getTelephone()).isEqualTo("6085559999");
+		assertThat(reloaded.getPets()).extracting(Pet::getId).containsExactlyElementsOf(petIds);
+	}
+
+	@Test
+	void int005ReloadedOwnerAggregateContainsPetsAndVisitsInExpectedOrder() {
+		Owner owner = this.owners.findById(6).orElseThrow();
+
+		assertThat(owner.getPets()).extracting(Pet::getName).containsExactly("Max", "Samantha");
+		Pet max = owner.getPet("Max");
+		Pet samantha = owner.getPet("Samantha");
+		assertThat(max.getVisits()).extracting(Visit::getDate)
+			.containsExactly(LocalDate.of(2013, 1, 2), LocalDate.of(2013, 1, 3));
+		assertThat(samantha.getVisits()).extracting(Visit::getDate)
+			.containsExactly(LocalDate.of(2013, 1, 1), LocalDate.of(2013, 1, 4));
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/owner/integration/OwnerValidationIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/integration/OwnerValidationIntegrationTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.owner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import jakarta.validation.Validator;
+
+/**
+ * Bean Validation integration coverage for reviewed Owner scenarios.
+ */
+class OwnerValidationIntegrationTests {
+
+	private final Validator validator = createValidator();
+
+	@Test
+	void int006OwnerBeanValidationRejectsRequiredFieldsAndInvalidTelephone() {
+		Owner owner = new Owner();
+		owner.setFirstName("");
+		owner.setLastName("");
+		owner.setAddress("");
+		owner.setCity("");
+		owner.setTelephone("12345");
+
+		Set<String> violationPaths = this.validator.validate(owner)
+			.stream()
+			.map(violation -> violation.getPropertyPath().toString())
+			.collect(Collectors.toSet());
+
+		assertThat(violationPaths).containsExactlyInAnyOrder("firstName", "lastName", "address", "city", "telephone");
+	}
+
+	private Validator createValidator() {
+		LocalValidatorFactoryBean localValidatorFactoryBean = new LocalValidatorFactoryBean();
+		localValidatorFactoryBean.afterPropertiesSet();
+		return localValidatorFactoryBean;
+	}
+
+}


### PR DESCRIPTION
Part of the Owner backend automation split.

Scope:
- Adds Owner repository, Bean Validation, and controller binding integration coverage.

Test count:
- 7 test executions.

Scenario IDs:
- INT-002, INT-003, INT-004, INT-005, INT-006, INT-007, INT-008.

Review guidance:
- This is the intentional 7-test exception: integration files were kept intact instead of mixing unit tests into the integration review surface.

Verification:
- Merge-union branch merged foundation + E2E + integration + unit splits with no conflicts.
- Merge-union diff matched the combined automation branch with no tracked-file differences.
- Full backend suite passed from the merge-union result: `./mvnw test` equivalent with local env overrides for occupied host 5432 and PostgreSQL timezone compatibility.
- Maven console: tests=85 failures=0 errors=0 skipped=0.
- Owner automation JUnit XML: tests=24 failures=0 errors=0 skipped=0.
- JaCoCo report generated successfully at `target/site/jacoco/index.html`.

Local verification note:
- This Windows machine has a local PostgreSQL service on host 5432 and timezone `Asia/Calcutta`; verification used a temporary compose file mapping Postgres to 15432 and `-Duser.timezone=UTC`. Project files were not changed for that environment workaround.