### PR TITLE
fix: remove dead code in showVetList method in VetController

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -45,9 +45,7 @@ class VetController {
 	public String showVetList(@RequestParam(defaultValue = "1") int page, Model model) {
 		// Here we are returning an object of type 'Vets' rather than a collection of Vet
 		// objects so it is simpler for Object-Xml mapping
-		Vets vets = new Vets();
 		Page<Vet> paginated = findPaginated(page);
-		vets.getVetList().addAll(paginated.toList());
 		return addPaginationModel(page, paginated, model);
 	}
 

--- a/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.samples.petclinic.vet;
 
 import org.assertj.core.util.Lists;
@@ -35,6 +34,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Test class for the {@link VetController}
@@ -97,4 +97,15 @@ class VetControllerTests {
 			.andExpect(jsonPath("$.vetList[0].id").value(1));
 	}
 
+	@Test
+	void vetListHasNameHelen() throws Exception {
+		mockMvc.perform(get("/vets.html?page=1"))
+			.andExpect(status().isOk())
+			.andExpect(model().attributeExists("listVets"))
+			.andExpect(model().attribute("listVets", hasItem(allOf(hasProperty("firstName", is("Helen")),hasProperty("specialties", hasItem(hasProperty("name", is("radiology"))))))));
+
+
+	}
+
 }
+

--- a/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
@@ -106,6 +106,15 @@ class VetControllerTests {
 
 
 	}
+	@Test
+	void vetsJsonEndpointsReturnTwoVets() throws Exception {
+		mockMvc.perform(get("/vets"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.vetList", hasSize(2)))
+			.andExpect(jsonPath("$.vetList[0].firstName").value("James"))
+			.andExpect(jsonPath("$.vetList[1].firstName").value("Helen"));
+
+	}
 
 }
 


### PR DESCRIPTION
Problem: In VetController.java, showVetList method creates a Vets 
object and populates it but never adds it to the Spring model. 
This is dead/unused code.

Fix: Removed the 2 unnecessary lines.

Testing: Verified all 6 vets still showing correctly on /vets.html