### PR TITLE
Feature: show total veterinarians count on vets page

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -48,6 +48,7 @@ class VetController {
 		Vets vets = new Vets();
 		Page<Vet> paginated = findPaginated(page);
 		vets.getVetList().addAll(paginated.toList());
+		model.addAttribute("totalVets", paginated.getTotalElements());
 		return addPaginationModel(page, paginated, model);
 	}
 

--- a/src/main/resources/templates/vets/vetList.html
+++ b/src/main/resources/templates/vets/vetList.html
@@ -5,6 +5,8 @@
 <body>
 
   <h2 th:text="#{vets}">Veterinarians</h2>
+  <p>Total Veterinarians: <span th:text="${totalVets}">0</span></p>
+
 
   <table id="vets" class="table table-striped">
     <thead>


### PR DESCRIPTION
Problem: The vets page was not showing total number of vets.

Fix: 
- Added totalVets to model in VetController
- Added display in vetList.html

Testing: Verified "Total Veterinarians: 6" showing on /vets.html