### PR TITLE
Fix: add minimum length validation of 2 characters for firstName

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Person.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Person.java
@@ -29,12 +29,12 @@ import jakarta.validation.constraints.Size;
 public class Person extends BaseEntity {
 
 	@Column(length = 30)
-	@Size(max = 30)
+	@Size(min = 2, max = 30, message = "First name must be between 2 and 30 characters")
 	@NotBlank
 	private String firstName;
 
 	@Column(length = 30)
-	@Size(max = 30)
+	@Size(min = 2, max = 30, message = "Last name must be between 2 and 30 characters")
 	@NotBlank
 	private String lastName;
 

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -248,4 +248,15 @@ class OwnerControllerTests {
 			.andExpect(flash().attributeExists("error"));
 	}
 
+	@Test
+	void firstNameLengthCheck () throws Exception {
+		mockMvc.perform(post("/owners/new").param("firstName", "A")
+			.param("lastName" , "Gum")
+			.param("address" , "121 street nama")
+			.param("city", "manavur")
+			.param("telephone" , "0987654321"))
+			.andExpect(status().isOk())
+			.andExpect(model().attributeHasFieldErrors("owner", "firstName"));
+	}
+
 }


### PR DESCRIPTION
Problem: First name field was accepting single character names 
like "A" which are not valid names.

Fix: Added min=2 to @Size annotation in Person.java
@Size(min = 2, max = 30, message = "First name must be between 2 and 30 characters")

Testing:
- "A" → shows error "First name must be between 2 and 30 characters" ✅
- "Hi" → saves successfully ✅
- "John" → saves successfully ✅