### PR TITLE
Add test for updating pet with same name

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
@@ -179,6 +179,19 @@ class PetControllerTests {
 			.andExpect(view().name("redirect:/owners/{ownerId}"));
 	}
 
+	@Test
+	void processUpdateFormWithSameName() throws Exception {
+		mockMvc.perform(post("/owners/{ownerId}/pets/{petId}/edit", TEST_OWNER_ID, TEST_PET_ID).param("name", "petty") // same
+																														// name
+																														// as
+																														// existing
+																														// pet
+			.param("type", "hamster")
+			.param("birthDate", "2015-02-12"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(view().name("redirect:/owners/{ownerId}"));
+	}
+
 	@Nested
 	class ProcessUpdateFormHasErrors {
 


### PR DESCRIPTION
:-This PR adds a test case for PetController to verify that updating a pet while keeping the same existing name succeeds without triggering duplicate name validation.

Changes:-
-Added processUpdateFormWithSameName() test in PetControllerTests.
-Verified that updating a pet with its current name returns a successful redirect.
-Ensures duplicate-name validation only applies when the new name conflicts with another pet owned by the same owner.