### PR TITLE
Fix #2554: Validate owner and pet names against invalid input

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,15 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>17</source>
+          <target>17</target>
+          <release>17</release>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>native-maven-plugin</artifactId>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -249,15 +249,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>17</source>
-          <target>17</target>
-          <release>17</release>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>native-maven-plugin</artifactId>
       </plugin>

--- a/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
@@ -18,6 +18,8 @@ package org.springframework.samples.petclinic.model;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Simple JavaBean domain object adds a name property to <code>BaseEntity</code>. Used as
@@ -30,8 +32,11 @@ import jakarta.validation.constraints.NotBlank;
 @MappedSuperclass
 public class NamedEntity extends BaseEntity {
 
-	@Column
-	@NotBlank
+	@NotBlank(message = "Name is required")
+	@Size(max = 255, message = "Name cannot exceed 255 characters")
+	@Pattern(regexp = "^\\p{L}[\\p{L}0-9'\\s-]*$",
+			message = "Name must start with a letter and may contain letters, numbers, spaces, apostrophes, or hyphens")
+	@Column(name = "name")
 	private String name;
 
 	public String getName() {

--- a/src/main/java/org/springframework/samples/petclinic/model/Person.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Person.java
@@ -18,6 +18,7 @@ package org.springframework.samples.petclinic.model;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 /**
@@ -31,11 +32,15 @@ public class Person extends BaseEntity {
 	@Column(length = 30)
 	@Size(max = 30)
 	@NotBlank
+	@Pattern(regexp = "^\\p{L}[\\p{L}0-9'\\s-]*$",
+			message = "Name must start with a letter and may contain letters, numbers, spaces, apostrophes, or hyphens")
 	private String firstName;
 
 	@Column(length = 30)
 	@Size(max = 30)
 	@NotBlank
+	@Pattern(regexp = "^\\p{L}[\\p{L}0-9'\\s-]*$",
+			message = "Name must start with a letter and may contain letters, numbers, spaces, apostrophes, or hyphens")
 	private String lastName;
 
 	public String getFirstName() {


### PR DESCRIPTION
## Description

Fixes #2554

This PR fixes issue #2554 by improving validation for Owner and Pet name fields.

### Changes

- Reject names containing only numeric characters.
- Reject names containing only special characters.
- Reject excessively long names.
- Preserve support for valid alphabetic names.
- Added validation to prevent invalid input patterns.

Fixes #2554
