### PR TITLE
Add WelcomeController test, fix deprecated SerializationUtils, add Pe…

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
@@ -63,6 +63,16 @@ class PetValidatorTests {
 	}
 
 	@Test
+	void supportsPetClass() {
+		assertTrue(petValidator.supports(Pet.class));
+	}
+
+	@Test
+	void doesNotSupportNonPetClass() {
+		assertFalse(petValidator.supports(String.class));
+	}
+
+	@Test
 	void validate() {
 		petType.setName(petTypeName);
 		pet.setName(petName);

--- a/src/test/java/org/springframework/samples/petclinic/system/WelcomeControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/WelcomeControllerTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.system;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.aot.DisabledInAotMode;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@WebMvcTest(WelcomeController.class)
+@DisabledInNativeImage
+@DisabledInAotMode
+class WelcomeControllerTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void welcome() throws Exception {
+		mockMvc.perform(get("/")).andExpect(status().isOk()).andExpect(view().name("welcome"));
+	}
+
+}


### PR DESCRIPTION
…tValidator supports() tests

- Add WebMvcTest for WelcomeController (previously untested)
- Replace deprecated Spring SerializationUtils with standard Java serialization
- Add tests for PetValidator.supports() method