### PR TITLE
fix: add validation for owner and pet names to prevent numeric-only v…

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
@@ -18,6 +18,8 @@ package org.springframework.samples.petclinic.model;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern;
 
 /**
  * Simple JavaBean domain object adds a name property to <code>BaseEntity</code>. Used as
@@ -31,7 +33,9 @@ import jakarta.validation.constraints.NotBlank;
 public class NamedEntity extends BaseEntity {
 
 	@Column
-	@NotBlank
+	@NotBlank(message = "Name is required")
+	@Size(max = 255, message = "Name cannot exceed 255 characters")
+	@Pattern(regexp = ".*[a-zA-Z].*", message = "Name must contain at least one letter")
 	private String name;
 
 	public String getName() {

--- a/src/main/java/org/springframework/samples/petclinic/model/Person.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Person.java
@@ -19,6 +19,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern;
 
 /**
  * Simple JavaBean domain object representing an person.
@@ -31,11 +32,13 @@ public class Person extends BaseEntity {
 	@Column(length = 30)
 	@Size(max = 30)
 	@NotBlank
+	@Pattern(regexp = ".*[a-zA-Z].*", message = "First name must contain at least one letter")
 	private String firstName;
 
 	@Column(length = 30)
 	@Size(max = 30)
 	@NotBlank
+	@Pattern(regexp = ".*[a-zA-Z].*", message = "Last name must contain at least one letter")
 	private String lastName;
 
 	public String getFirstName() {


### PR DESCRIPTION
Problem

The Owner and Pet name fields only had @NotBlank validation, which allowed numeric-only values like "123", "987654", or "123 laghari" to be saved. This led to nonsensical data in the system.

Solution

Added comprehensive validation to the base classes (NamedEntity and Person) that both Owner and Pet inherit from:

Changes Made:

1. NamedEntity.java (base class for Pet.name):
  - Added @Size(maot exceed 255characters")
  - Added @Patternsage = "Name mustcontain at least one letter")
2. Person.java (baandOwner.lastName):
  - Added @Patternsage ="[First/Last] name must contain at least one letter")
  - Kept existing  constraints

Why This Approach:

- Consistency: Boton now share thesame rules through inheritance
- Clear messaging:about what's wrongwith their input
- Appropriate limireasonable for petnames), 30 chars for person names (matches existing DB
constraints)
- Letter requirement: Ensures at least one alphabetic character
prevents numeric-oens, spaces,apostrophes, etc.

Testing

Verified the fix by attempting to create:
- Owners with nume123", "456") →Validation error shown
- Pets with numeri→ Validation errorshown
- Valid names stil", "Buddy","O'Malley", "Jean-Luc")

This addresses the validation gap mentioned in the issue where users could previomes like "123" or"456".