### PR TITLE
All visits section added

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
@@ -92,6 +92,17 @@ class VisitController {
 		return "pets/createOrUpdateVisitForm";
 	}
 
+	@GetMapping("/owners/{ownerId}/pets/{petId}/visits")
+	public String showAllVisits(@PathVariable int ownerId, @PathVariable int petId, Map<String, Object> model) {
+		Owner owner = this.owners.findById(ownerId)
+			.orElseThrow(() -> new IllegalArgumentException("Owner not found with id: " + ownerId));
+		Pet pet = owner.getPet(petId);
+		model.put("pet", pet);
+		model.put("owner", owner);
+		model.put("visits", pet.getVisits());
+		return "pets/allVisits";
+	}
+
 	// Spring MVC calls method loadPetWithVisit(...) before processNewVisitForm is
 	// called
 	@PostMapping("/owners/{ownerId}/pets/{petId}/visits/new")

--- a/src/main/resources/templates/owners/ownerDetails.html
+++ b/src/main/resources/templates/owners/ownerDetails.html
@@ -58,20 +58,17 @@
       </td>
       <td valign="top">
         <table class="table-condensed">
-          <thead>
-            <tr>
-              <th th:text="#{visitDate}">Visit Date</th>
-              <th th:text="#{description}">Description</th>
-            </tr>
-          </thead>
-          <tr th:each="visit : ${pet.visits}">
-            <td th:text="${#temporals.format(visit.date, 'yyyy-MM-dd')}"></td>
-            <td th:text="${visit?.description}"></td>
-          </tr>
           <tr>
-            <td><a th:href="@{__${owner.id}__/pets/__${pet.id}__/edit}" th:text="#{editPet}">Edit Pet</a></td>
-            <td><a th:href="@{__${owner.id}__/pets/__${pet.id}__/visits/new}" th:text="#{addVisit}">Add Visit</a></td>
-          </tr>
+            <!-- The inline style adds a 15-pixel blank space to the right of the cell -->
+            <style> .spaced-cell { padding-right: 15px; } </style>
+        
+            <td class="spaced-cell"><a th:href="@{__${owner.id}__/pets/__${pet.id}__/edit}" th:text="#{editPet}">Edit Pet</a></td>
+            <td class="spaced-cell"><a th:href="@{__${owner.id}__/pets/__${pet.id}__/visits/new}" th:text="#{addVisit}">Add Visit</a></td>
+            <td>
+                <a th:href="@{/owners/{ownerId}/pets/{petId}/visits(ownerId=${owner.id},petId=${pet.id})}">All Visits</a>
+            </td>
+        </tr>
+        
         </table>
       </td>
     </tr>

--- a/src/main/resources/templates/pets/allVisits.html
+++ b/src/main/resources/templates/pets/allVisits.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+
+<html xmlns:th="https://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout (~{::body},'owners')}">
+
+<body>
+
+<h2>Visit History</h2>
+
+<div class="form-horizontal">
+
+    <div class="form-group">
+        <label class="col-sm-2 control-label">Owner</label>
+        <div class="col-sm-10">
+            <p class="form-control-static"
+               th:text="${owner.firstName + ' ' + owner.lastName}"></p>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <label class="col-sm-2 control-label">Pet</label>
+        <div class="col-sm-10">
+            <p class="form-control-static"
+               th:text="${pet.name}"></p>
+        </div>
+    </div>
+
+</div>
+
+<table class="table table-striped">
+
+    <thead>
+    <tr>
+        <th>Visit Date</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+
+    <tr th:each="visit : ${visits}">
+        <td th:text="${#temporals.format(visit.date,'yyyy-MM-dd')}"></td>
+        <td th:text="${visit.description}"></td>
+    </tr>
+
+    <tr th:if="${#lists.isEmpty(visits)}">
+        <td colspan="2" class="text-center">
+            No visits available.
+        </td>
+    </tr>
+
+    </tbody>
+
+</table>
+
+<div class="form-group">
+    <a class="btn btn-default"
+       th:href="@{/owners/{ownerId}(ownerId=${owner.id})}">
+        Back
+    </a>
+
+    <a class="btn btn-primary"
+       th:href="@{/owners/{ownerId}/pets/{petId}/visits/new(ownerId=${owner.id},petId=${pet.id})}">
+        Add Visit
+    </a>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

This PR adds a dedicated page to display all visits associated with a specific pet.

Previously, visit history was displayed only on the Owner Details page. With this change, users can click the **"All Visits"** link for a pet to navigate to a separate page containing the complete visit history.

## Changes

- Added an **"All Visits"** link for each pet on the Owner Details page.
- Added a new controller endpoint to handle viewing all visits for a pet.
- Created a new Thymeleaf template to display the visit history.
- Added navigation back to the Owner Details page.

## Screenshots

### Before

<img width="554" height="127" alt="Screenshot 2026-07-05 125913" src="https://github.com/user-attachments/assets/01cd9237-a5f3-4707-a67d-8f6bc615acf9" />

### After
<img width="629" height="440" alt="Screenshot 2026-07-05 175504" src="https://github.com/user-attachments/assets/4a6e04a3-594c-4d5a-8d69-189cba4c47a3" />
<img width="627" height="452" alt="Screenshot 2026-07-05 175556" src="https://github.com/user-attachments/assets/31778160-2dd8-4f2f-a653-300d5e550fbd" />

## Testing

- Verified that the "All Visits" link opens the correct page.
- Verified that only visits for the selected pet are displayed.
- Verified navigation back to the Owner Details page