### PR TITLE
Add validation to prevent numeric-only names for Owner and Pet. Adds …

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
@@ -18,6 +18,8 @@ package org.springframework.samples.petclinic.model;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Simple JavaBean domain object adds a name property to <code>BaseEntity</code>. Used as
@@ -31,7 +33,9 @@ import jakarta.validation.constraints.NotBlank;
 public class NamedEntity extends BaseEntity {
 
 	@Column
-	@NotBlank
+	@NotBlank(message = "Name is required")
+	@Size(max = 255, message = "Name cannot exceed 255 characters")
+	@Pattern(regexp = ".*[a-zA-Z].*", message = "Name must contain at least one letter")
 	private String name;
 
 	public String getName() {

--- a/src/main/java/org/springframework/samples/petclinic/model/Person.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Person.java
@@ -19,6 +19,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern;
 
 /**
  * Simple JavaBean domain object representing an person.
@@ -31,11 +32,13 @@ public class Person extends BaseEntity {
 	@Column(length = 30)
 	@Size(max = 30)
 	@NotBlank
+	@Pattern(regexp = ".*[a-zA-Z].*", message = "Name must contain at least one letter")
 	private String firstName;
 
 	@Column(length = 30)
 	@Size(max = 30)
 	@NotBlank
+	@Pattern(regexp = ".*[a-zA-Z].*", message = "Name must contain at least one letter")
 	private String lastName;
 
 	public String getFirstName() {

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
@@ -41,6 +41,9 @@ public class PetValidator implements Validator {
 		if (!StringUtils.hasText(name)) {
 			errors.rejectValue("name", REQUIRED, REQUIRED);
 		}
+		else if (!name.matches(".*[a-zA-Z].*")) {
+			errors.rejectValue("name", "invalid", "Name must contain at least one letter");
+		}
 
 		// type validation
 		if (pet.isNew() && pet.getType() == null) {


### PR DESCRIPTION
…@Pattern validation to Person.java requiring at least one letter in firstName/lastName, and adds matching manual validation to PetValidator.java for Pet name. Fixes #2554