### PR TITLE
Fix owner search with surrounding whitespace

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -99,6 +99,9 @@ class OwnerController {
 		if (lastName == null) {
 			lastName = ""; // empty string signifies broadest possible search
 		}
+		else {
+			lastName = lastName.strip();
+		}
 
 		// find owners by last name
 		Page<Owner> ownersResults = findPaginatedForOwnersLastName(page, lastName);

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -44,6 +44,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -153,6 +155,32 @@ class OwnerControllerTests {
 		mockMvc.perform(get("/owners?page=1").param("lastName", "Franklin"))
 			.andExpect(status().is3xxRedirection())
 			.andExpect(view().name("redirect:/owners/" + TEST_OWNER_ID));
+	}
+
+	@Test
+	void processFindFormIgnoresSurroundingWhitespace() throws Exception {
+		Page<Owner> tasks = new PageImpl<>(List.of(george()));
+		when(this.owners.findByLastNameStartingWith(eq("Franklin"), any(Pageable.class))).thenReturn(tasks);
+
+		for (String lastName : List.of(" Franklin", "Franklin ", " Franklin ")) {
+			mockMvc.perform(get("/owners?page=1").param("lastName", lastName))
+				.andExpect(status().is3xxRedirection())
+				.andExpect(view().name("redirect:/owners/" + TEST_OWNER_ID));
+		}
+
+		verify(this.owners, times(3)).findByLastNameStartingWith(eq("Franklin"), any(Pageable.class));
+	}
+
+	@Test
+	void processFindFormWithWhitespaceOnlyLastNameReturnsAllOwners() throws Exception {
+		Page<Owner> tasks = new PageImpl<>(List.of(george(), new Owner()));
+		when(this.owners.findByLastNameStartingWith(eq(""), any(Pageable.class))).thenReturn(tasks);
+
+		mockMvc.perform(get("/owners?page=1").param("lastName", "   "))
+			.andExpect(status().isOk())
+			.andExpect(view().name("owners/ownersList"));
+
+		verify(this.owners).findByLastNameStartingWith(eq(""), any(Pageable.class));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Trim surrounding whitespace from the owner last-name search input before querying the repository.

## Problem

Owner searches containing leading or trailing whitespace did not behave like the equivalent trimmed search.

## Changes

- normalize the submitted last name with `String.strip()`;
- preserve the existing behavior for a missing search value;
- add regression coverage for leading, trailing, and combined surrounding whitespace;
- add coverage for whitespace-only searches.

## Testing

- focused `OwnerControllerTests`: 15 passed;
- Maven validation: passed;
- Gradle validation: passed;
- independent technical review: approved.

## Acceptance criteria

- leading whitespace is ignored;
- trailing whitespace is ignored;
- surrounding whitespace is ignored;
- existing trimmed-input behavior is preserved;
- whitespace-only input follows the empty-search behavior.

## Scope

Changed files:

- `src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java`
- `src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java`

No database, migration, API-contract, dependency, infrastructure, or configuration change.

## Commit

`4b7371f6b963302a0ef53b681ff9a61d83f4ed89`

## DCO

The commit contains a valid `Signed-off-by` trailer.

## Reviewer focus

- whether `String.strip()` is the appropriate normalization method;
- whether whitespace-only input should continue to behave as an empty search;
- whether the regression tests cover the intended behavior sufficiently;
- whether the change preserves existing owner-search behavior.
