### PR TITLE
Fix owner addPet and pet validation

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -95,7 +95,7 @@ public class Owner extends Person {
 	}
 
 	public void addPet(Pet pet) {
-		if (pet.isNew()) {
+		if (pet.isNew() || getPet(pet.getId()) == null) {
 			getPets().add(pet);
 		}
 	}

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
@@ -33,6 +33,10 @@ public class PetValidator implements Validator {
 
 	private static final String REQUIRED = "required";
 
+	private static final String TOO_LONG = "tooLong";
+
+	private static final int MAX_NAME_LENGTH = 30;
+
 	@Override
 	public void validate(Object obj, Errors errors) {
 		Pet pet = (Pet) obj;
@@ -40,6 +44,10 @@ public class PetValidator implements Validator {
 		// name validation
 		if (!StringUtils.hasText(name)) {
 			errors.rejectValue("name", REQUIRED, REQUIRED);
+		}
+
+		if (name != null && name.length() > MAX_NAME_LENGTH) {
+			errors.rejectValue("name", TOO_LONG, TOO_LONG);
 		}
 
 		// type validation

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerTests.java
@@ -1,0 +1,34 @@
+package org.springframework.samples.petclinic.owner;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OwnerTests {
+
+	@Test
+	void addPetShouldAddPersistedPet() {
+		Owner owner = new Owner();
+
+		Pet pet = new Pet();
+		pet.setId(5);
+
+		owner.addPet(pet);
+
+		assertThat(owner.getPets()).containsExactly(pet);
+	}
+
+	@Test
+	void addPetShouldNotAddDuplicatePet() {
+		Owner owner = new Owner();
+
+		Pet pet = new Pet();
+		pet.setId(5);
+
+		owner.addPet(pet);
+		owner.addPet(pet);
+
+		assertThat(owner.getPets()).containsExactly(pet);
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
@@ -84,6 +84,18 @@ class PetValidatorTests {
 		assertFalse(errors.hasErrors());
 	}
 
+	@Test
+	void validateWithPetNameOfMaxLength() {
+		petType.setName(petTypeName);
+		pet.setName("123456789012345678901234567890");
+		pet.setType(petType);
+		pet.setBirthDate(petBirthDate);
+
+		petValidator.validate(pet, errors);
+
+		assertFalse(errors.hasFieldErrors("name"));
+	}
+
 	@Nested
 	class ValidateHasErrors {
 
@@ -91,6 +103,18 @@ class PetValidatorTests {
 		void validateWithInvalidPetName() {
 			petType.setName(petTypeName);
 			pet.setName("");
+			pet.setType(petType);
+			pet.setBirthDate(petBirthDate);
+
+			petValidator.validate(pet, errors);
+
+			assertTrue(errors.hasFieldErrors("name"));
+		}
+
+		@Test
+		void validateWithPetNameTooLong() {
+			petType.setName(petTypeName);
+			pet.setName("1234567890123456789012345678901");
 			pet.setType(petType);
 			pet.setBirthDate(petBirthDate);
 


### PR DESCRIPTION
Fixes the Owner.addPet() logic so persisted pets are added when they are not already associated with the owner.

Adds pet name length validation to reject names longer than 30 characters.

Added unit tests covering persisted pet association, duplicate prevention, and pet name length validation.

All existing tests pass.