### PR TITLE
Fix Owner.addPet for persisted pets and validate pet names

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -95,9 +95,18 @@ public class Owner extends Person {
 	}
 
 	public void addPet(Pet pet) {
-		if (pet.isNew()) {
-			getPets().add(pet);
+		if (pet == null) {
+			return;
 		}
+		if (getPets().contains(pet)) {
+			return;
+		}
+		for (Pet existingPet : getPets()) {
+			if (!existingPet.isNew() && !pet.isNew() && Objects.equals(existingPet.getId(), pet.getId())) {
+				return;
+			}
+		}
+		getPets().add(pet);
 	}
 
 	/**

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
@@ -33,6 +33,8 @@ public class PetValidator implements Validator {
 
 	private static final String REQUIRED = "required";
 
+	private static final int MAX_NAME_LENGTH = 30;
+
 	@Override
 	public void validate(Object obj, Errors errors) {
 		Pet pet = (Pet) obj;
@@ -40,6 +42,9 @@ public class PetValidator implements Validator {
 		// name validation
 		if (!StringUtils.hasText(name)) {
 			errors.rejectValue("name", REQUIRED, REQUIRED);
+		}
+		else if (name.length() > MAX_NAME_LENGTH) {
+			errors.rejectValue("name", "size", "Name must be no more than 30 characters");
 		}
 
 		// type validation

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.owner;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OwnerTests {
+
+	@Test
+	void addPetAddsPersistedPet() {
+		Owner owner = new Owner();
+		Pet pet = new Pet();
+		pet.setId(5);
+		pet.setName("Buddy");
+
+		owner.addPet(pet);
+
+		assertTrue(owner.getPets().contains(pet));
+		assertEquals(1, owner.getPets().size());
+	}
+
+	@Test
+	void addPetDoesNotAddDuplicatePet() {
+		Owner owner = new Owner();
+		Pet pet = new Pet();
+		pet.setId(5);
+		pet.setName("Buddy");
+
+		owner.addPet(pet);
+		owner.addPet(pet);
+
+		assertEquals(1, owner.getPets().size());
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
@@ -122,6 +122,18 @@ class PetValidatorTests {
 			assertTrue(errors.hasFieldErrors("birthDate"));
 		}
 
+		@Test
+		void validateWithLongPetName() {
+			petType.setName(petTypeName);
+			pet.setName("A".repeat(31));
+			pet.setType(petType);
+			pet.setBirthDate(petBirthDate);
+
+			petValidator.validate(pet, errors);
+
+			assertTrue(errors.hasFieldErrors("name"));
+		}
+
 	}
 
 }


### PR DESCRIPTION
**Fixes #2600** by updating Owner.addPet to correctly associate persisted pets with an owner and by enforcing the pet name length constraint during validation.

**What changed**

- Updated Owner.addPet to add non-null pets when they are not already associated with the owner, including pets that already have an ID.
- Prevented duplicate pets from being added to the same owner.
- Extended PetValidator to reject pet names longer than 30 characters, matching the database column size.

**Added regression tests covering:**

- persisted pet association,
- duplicate pet prevention,
- long-name validation.

**Testing**
Verified with:
`mvn -q -Dtest=OwnerTests,PetValidatorTests test`