### PR TITLE
test: add unit test for showOwner with non-existent id

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.aot.DisabledInAotMode;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -274,6 +274,15 @@ class OwnerControllerTests {
 			.andExpect(status().is3xxRedirection())
 			.andExpect(redirectedUrl("/owners/" + pathOwnerId + "/edit"))
 			.andExpect(flash().attributeExists("error"));
+	}
+
+	@Test
+	void showOwnerNotFound() {
+		int nonExistingOwnerId = 999;
+		given(this.owners.findById(nonExistingOwnerId)).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> mockMvc.perform(get("/owners/{ownerId}", nonExistingOwnerId)))
+			.hasRootCauseInstanceOf(IllegalArgumentException.class);
 	}
 
 }


### PR DESCRIPTION
### Summary of changes
- Added a test case `showOwnerNotFound` in `OwnerControllerTests` to verify that requesting a non-existent owner ID throws an `IllegalArgumentException`.
- Verified with `./mvnw spring-javaformat:apply` and `./mvnw test`.