### PR TITLE
docs: Fix formatting in Docker container instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ See below for more details.
 
 There is no `Dockerfile` in this project. You can build a container image (if you have a docker daemon) using the Spring Boot build plugin:
 
+```bash
+./mvnw spring-boot:build-image
+```
+
 ## Running the Container Image
 
 ```bash
-./mvnw spring-boot:build-image
 docker images | grep petclinic
 docker run -p 8080:8080 docker.io/library/spring-petclinic:latest
 ```


### PR DESCRIPTION
### Summary
This PR fixes a minor Markdown formatting bug in the `README.md` under the "Building a Container" section. 

Currently, the `bash` code block for `./mvnw spring-boot:build-image` is improperly merged with the code block for the "Running the Container Image" section. This PR splits the `bash` blocks so the commands align properly under their respective headings. 

This makes the README render correctly and makes the instructions easier for new developers to copy/paste.