### PR TITLE
Fix persisted pet validation and name length

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -95,7 +95,7 @@ public class Owner extends Person {
 	}
 
 	public void addPet(Pet pet) {
-		if (pet.isNew()) {
+		if (pet != null && !getPets().contains(pet)) {
 			getPets().add(pet);
 		}
 	}

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
@@ -33,6 +33,8 @@ public class PetValidator implements Validator {
 
 	private static final String REQUIRED = "required";
 
+	private static final int MAX_NAME_LENGTH = 30;
+
 	@Override
 	public void validate(Object obj, Errors errors) {
 		Pet pet = (Pet) obj;
@@ -40,6 +42,9 @@ public class PetValidator implements Validator {
 		// name validation
 		if (!StringUtils.hasText(name)) {
 			errors.rejectValue("name", REQUIRED, REQUIRED);
+		}
+		else if (name.length() > MAX_NAME_LENGTH) {
+			errors.rejectValue("name", "maxlength", "Name must be 30 characters or less");
 		}
 
 		// type validation

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.owner;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OwnerTests {
+
+	@Test
+	void addPersistedPet() {
+		Owner owner = new Owner();
+		Pet pet = new Pet();
+		pet.setId(1);
+
+		owner.addPet(pet);
+
+		assertEquals(1, owner.getPets().size());
+		assertEquals(pet, owner.getPets().get(0));
+	}
+
+	@Test
+	void doesNotAddDuplicatePet() {
+		Owner owner = new Owner();
+		Pet pet = new Pet();
+		pet.setId(1);
+
+		owner.addPet(pet);
+		owner.addPet(pet);
+
+		assertEquals(1, owner.getPets().size());
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
@@ -100,6 +100,18 @@ class PetValidatorTests {
 		}
 
 		@Test
+		void validateWithPetNameLongerThan30Characters() {
+			petType.setName(petTypeName);
+			pet.setName("ThisPetNameIsDefinitelyLongerThanThirtyCharacters");
+			pet.setType(petType);
+			pet.setBirthDate(petBirthDate);
+
+			petValidator.validate(pet, errors);
+
+			assertTrue(errors.hasFieldErrors("name"));
+		}
+
+		@Test
 		void validateWithInvalidPetType() {
 			pet.setName(petName);
 			pet.setType(null);


### PR DESCRIPTION
## Description

Fix persisted pet handling in `Owner.addPet()` and add pet name length validation.

## Changes

- Allow persisted pets to be added to an owner.
- Prevent duplicate pets from being added.
- Validate pet names to a maximum of 30 characters.
- Add tests for persisted pets and duplicate prevention.
- Add test for pet names exceeding 30 characters.

## Testing

mvn -Dtest=OwnerTests,PetValidatorTests test

Result:
- Tests run: 9
- Failures: 0
- Errors: 0
- Skipped: 0
- BUILD SUCCESS