### PR TITLE
[Archeo] Erros de validação de negócio (owner ou pet não encontrados) devem resultar em respostas HTTP apropriadas (404 Not Found) em vez de exceções genéricas não tratadas.

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.util.Map;
 import java.util.Optional;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.WebDataBinder;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.validation.Valid;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -64,12 +66,12 @@ class VisitController {
 	public Visit loadPetWithVisit(@PathVariable("ownerId") int ownerId, @PathVariable("petId") int petId,
 			Map<String, Object> model) {
 		Optional<Owner> optionalOwner = owners.findById(ownerId);
-		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
+		Owner owner = optionalOwner.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
 				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
 
 		Pet pet = owner.getPet(petId);
 		if (pet == null) {
-			throw new IllegalArgumentException(
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND,
 					"Pet with id " + petId + " not found for owner with id " + ownerId + ".");
 		}
 		model.put("pet", pet);

--- a/src/test/java/org/springframework/samples/petclinic/owner/VisitControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/VisitControllerTests.java
@@ -106,4 +106,21 @@ class VisitControllerTests {
 			.andExpect(view().name("pets/createOrUpdateVisitForm"));
 	}
 
+	@Test
+	void initNewVisitFormReturnsNotFoundWhenOwnerIsMissing() throws Exception {
+		int missingOwnerId = 999;
+		given(this.owners.findById(missingOwnerId)).willReturn(Optional.empty());
+
+		mockMvc.perform(get("/owners/{ownerId}/pets/{petId}/visits/new", missingOwnerId, TEST_PET_ID))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void initNewVisitFormReturnsNotFoundWhenPetIsMissing() throws Exception {
+		int missingPetId = 999;
+
+		mockMvc.perform(get("/owners/{ownerId}/pets/{petId}/visits/new", TEST_OWNER_ID, missingPetId))
+			.andExpect(status().isNotFound());
+	}
+
 }


### PR DESCRIPTION
Correção autônoma para a issue #10799.

O método loadPetWithVisit() não trata o caso em que owner.getPet(petId) retorna null. Embora haja uma verificação na linha 71, a chamada a pet.addVisit(visit) na linha 79 pode falhar com NullPointerException se a verificação for contornada ou se houver condição de corrida. Além disso, IllegalArgumentException é uma escolha inadequada para erros de negócio em um controlador Spring — deveria ser uma exceção específica do domínio ou ser mapeada para uma resposta HTTP apropriada.