### PR TITLE
[Archeo] Toda operação de escrita deve validar que o recurso solicitado pertence ao proprietário autenticado, prevenindo manipulação de URLs.

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
@@ -97,6 +97,11 @@ class VisitController {
 	@PostMapping("/owners/{ownerId}/pets/{petId}/visits/new")
 	public String processNewVisitForm(@ModelAttribute Owner owner, @PathVariable int petId, @Valid Visit visit,
 			BindingResult result, RedirectAttributes redirectAttributes) {
+		if (owner.getPet(petId) == null) {
+			throw new IllegalArgumentException(
+					"Pet with id " + petId + " does not belong to owner with id " + owner.getId() + ".");
+		}
+
 		if (visit.getDate() != null && !visit.getDate().isAfter(LocalDate.now())) {
 			result.rejectValue("date", "typeMismatch.visitDate");
 		}


### PR DESCRIPTION
Correção autônoma para a issue #10801.

O método processNewVisitForm() recebe petId como @PathVariable int, mas não valida se o petId corresponde ao pet associado ao owner. Não há verificação de que o petId passado no path corresponde ao pet contido no objeto owner. Isso pode permitir que um usuário modifique a URL para adicionar uma visita a um pet que não pertence ao owner.